### PR TITLE
Encoding fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,13 @@
     <name>sokrates</name>
     <packaging>pom</packaging>
     
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
     <modules>
         <module>common</module>
         <module>codeanalyzer</module>


### PR DESCRIPTION
Hi Zeljko,

I suggest this fix to avoid the following encoding problems I just ran into while building on macOS:

../sokrates/codeexplorer/src/main/java/nl/obren/sokrates/codeexplorer/dependencies/DependenciesPane.java:[2,23] unmappable character (0xC5) for encoding US-ASCII.

Best regards,
- Mark