### PR TITLE
C#: dependency tree not correct with overlapping namespace hierarchy in 2 components

### DIFF
--- a/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/lang/csharp/CSharpHeuristicDependenciesExtractor.java
+++ b/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/lang/csharp/CSharpHeuristicDependenciesExtractor.java
@@ -33,7 +33,7 @@ public class CSharpHeuristicDependenciesExtractor extends HeuristicDependenciesE
                 String namespaceName = content.substring(startIndexOfNamespaceName + NAMESPACE_PREFIX.length(), endIndexOfNamespaceName).trim();
                 DependencyAnchor dependencyAnchor = new DependencyAnchor(namespaceName);
                 dependencyAnchor.setCodeFragment(content.substring(startIndexOfNamespaceName, endIndexOfNamespaceName + 1).trim());
-                dependencyAnchor.getDependencyPatterns().add("[ ]*using* " + namespaceName.replace(".", "[.]") + "([.][A-Z].*|[.][*]|);");
+                dependencyAnchor.getDependencyPatterns().add("[ ]*using[ ]+" + namespaceName.replace(".", "[.]") + "([.][*]|);");
                 dependencyAnchor.getSourceFiles().add(sourceFile);
                 anchors.add(dependencyAnchor);
             }

--- a/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/lang/csharp/CSharpHeuristicDependenciesExtractorTest.java
+++ b/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/lang/csharp/CSharpHeuristicDependenciesExtractorTest.java
@@ -4,11 +4,16 @@
 
 package nl.obren.sokrates.sourcecode.lang.csharp;
 
+import nl.obren.sokrates.common.utils.ProgressFeedback;
 import nl.obren.sokrates.sourcecode.SourceFile;
+import nl.obren.sokrates.sourcecode.aspects.NamedSourceCodeAspect;
+import nl.obren.sokrates.sourcecode.dependencies.Dependency;
 import nl.obren.sokrates.sourcecode.dependencies.DependencyAnchor;
 import nl.obren.sokrates.sourcecode.lang.csharp.CSharpHeuristicDependenciesExtractor;
+
 import org.junit.Test;
 import java.io.File;
+import java.util.Arrays;
 import java.util.List;
 
 import static junit.framework.TestCase.assertEquals;
@@ -23,7 +28,90 @@ public class CSharpHeuristicDependenciesExtractorTest {
         assertEquals(anchors.size(), 1);
         assertEquals(anchors.get(0).getAnchor(), "a");
         assertEquals(anchors.get(0).getDependencyPatterns().size(), 1);
-        assertEquals(anchors.get(0).getDependencyPatterns().get(0), "[ ]*using* a([.][A-Z].*|[.][*]|);");
+        assertEquals(anchors.get(0).getDependencyPatterns().get(0), "[ ]*using[ ]+a([.][*]|);");
+    }
+
+    @Test
+    public void extractDependencies() throws Exception {
+        CSharpAnalyzer analyzer = new CSharpAnalyzer();
+
+        NamedSourceCodeAspect rootComponent = new NamedSourceCodeAspect("Root");
+        String codeRoot1 = "namespace Root.First {\n" +
+        "}";
+        String codeRoot2 = "namespace Root.Second {\n" +
+        "}";
+        SourceFile sourceFileRoot1 = new SourceFile(new File("a.cs"), codeRoot1);
+        sourceFileRoot1.getLogicalComponents().add(rootComponent);
+        SourceFile sourceFileRoot2 = new SourceFile(new File("b.cs"), codeRoot2);
+        sourceFileRoot2.getLogicalComponents().add(rootComponent);
+
+        String user = "using Root.First;\n" +
+        "\n" + 
+        "namespace User.My {}";
+        SourceFile usageFile = new SourceFile(new File("c.cs"), user);
+        usageFile.getLogicalComponents().add(new NamedSourceCodeAspect("User"));
+
+        List<Dependency> dependencies = analyzer.extractDependencies(Arrays.asList(sourceFileRoot1, sourceFileRoot2, usageFile), new ProgressFeedback()).getDependencies();
+        assertEquals(1, dependencies.size());
+        assertEquals("User.My -> Root.First", dependencies.get(0).getDependencyString());
+        assertEquals("User -> Root", dependencies.get(0).getComponentDependency(""));
+    }
+
+    @Test
+    public void extractDependenciesSubNamespaces() throws Exception {
+        CSharpAnalyzer analyzer = new CSharpAnalyzer();
+
+        NamedSourceCodeAspect rootComponent = new NamedSourceCodeAspect("Root");
+        String codeRoot1 = "namespace Root {\n" +
+        "}";
+        String codeRoot2 = "namespace Root.Other {\n" +
+        "}";
+        SourceFile sourceFileRoot1 = new SourceFile(new File("a.cs"), codeRoot1);
+        sourceFileRoot1.getLogicalComponents().add(rootComponent);
+        SourceFile sourceFileRoot2 = new SourceFile(new File("h.cs"), codeRoot2);
+        sourceFileRoot2.getLogicalComponents().add(rootComponent);
+
+        String user = "using Root;\n" +
+        "\n" + 
+        "namespace User.My {}";
+        SourceFile usageFile = new SourceFile(new File("c.cs"), user);
+        usageFile.getLogicalComponents().add(new NamedSourceCodeAspect("User"));
+
+        List<Dependency> dependencies = analyzer.extractDependencies(Arrays.asList(sourceFileRoot1, sourceFileRoot2, usageFile), new ProgressFeedback()).getDependencies();
+        assertEquals(1, dependencies.size());
+        assertEquals("User.My -> Root", dependencies.get(0).getDependencyString());
+        assertEquals("User -> Root", dependencies.get(0).getComponentDependency(""));
+    }
+
+    @Test
+    public void extractDependenciesWithNamespaceOverlappingSubProjects() throws Exception {
+        CSharpAnalyzer analyzer = new CSharpAnalyzer();
+
+        NamedSourceCodeAspect rootComponent = new NamedSourceCodeAspect("Root");
+        String codeRoot1 = "namespace Root {\n" +
+        "}";
+        String codeRoot2 = "namespace Root.Other {\n" +
+        "}";
+        SourceFile sourceFileRoot1 = new SourceFile(new File("a.cs"), codeRoot1);
+        sourceFileRoot1.getLogicalComponents().add(rootComponent);
+        SourceFile sourceFileRoot2 = new SourceFile(new File("h.cs"), codeRoot2);
+        sourceFileRoot2.getLogicalComponents().add(rootComponent);
+
+        String code2 = "namespace Root.SubInOtherComponent {\n" +
+        "}";
+        SourceFile sourceFileSub1 = new SourceFile(new File("b.cs"), code2);
+        sourceFileSub1.getLogicalComponents().add(new NamedSourceCodeAspect("Root.Sub"));
+
+        String user = "using Root.SubInOtherComponent;\n" +
+        "\n" + 
+        "namespace User.My {}";
+        SourceFile usageFile = new SourceFile(new File("c.cs"), user);
+        usageFile.getLogicalComponents().add(new NamedSourceCodeAspect("User"));
+
+        List<Dependency> dependencies = analyzer.extractDependencies(Arrays.asList(sourceFileRoot1, sourceFileRoot2, sourceFileSub1, usageFile), new ProgressFeedback()).getDependencies();
+        assertEquals(1, dependencies.size());
+        assertEquals("User.My -> Root.SubInOtherComponent", dependencies.get(0).getDependencyString());
+        assertEquals("User -> Root.Sub", dependencies.get(0).getComponentDependency(""));
     }
 
 }


### PR DESCRIPTION
When a subtree of the namespace hierarchy is in a another component, map `using` directives to the correct component.

Case:

Component `Root`
  -> `namespace Root`
  -> `namespace Root.Other`

Component `Root.Sub`
  -> `namespace Root.Sub`

Component `User`
  files with `using Root.Sub;`

With the 0.9 release, Sokrates detected a dependency from `User -> Root` and from `User -> Root.Sub` with the same set of files. Only the last one is correct. 

I added a few tests to cover this case and adapted the regular expression.