### PR TITLE
[PL/SQL Analyzer] Fixed unit name bug

### DIFF
--- a/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/lang/plsql/PlSqlHeuristicUnitsExtractor.java
+++ b/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/lang/plsql/PlSqlHeuristicUnitsExtractor.java
@@ -102,6 +102,14 @@ public class PlSqlHeuristicUnitsExtractor {
             strippedLine = strippedLine.substring(0, strippedLine.indexOf("(")).trim();
         }
 
+        if(strippedLine.contains("RETURN")) {
+            strippedLine = strippedLine.substring(0, strippedLine.indexOf("RETURN")).trim();
+        }
+
+        if(strippedLine.contains("return")) {
+            strippedLine = strippedLine.substring(0, strippedLine.indexOf("return")).trim();
+        }
+
         if(strippedLine.contains(".")) {
             strippedLine = strippedLine.substring(strippedLine.indexOf(".")+1).trim();
         }


### PR DESCRIPTION
Fixed bug with 'return' statement being part of the unit name.