### PR TITLE
RenameSuggestion

### DIFF
--- a/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/cleaners/SourceCodeCleanerUtils.java
+++ b/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/cleaners/SourceCodeCleanerUtils.java
@@ -116,7 +116,7 @@ public class SourceCodeCleanerUtils {
         return cleaner.clean(content);
     }
 
-    public static CleanedContent cleanSingeLineCommentsAndEmptyLines(String content, List<String> singleLineCommentStarts) {
+    public static CleanedContent cleanSingleLineCommentsAndEmptyLines(String content, List<String> singleLineCommentStarts) {
         content = SourceCodeCleanerUtils.normalizeLineEnds(content);
         content = SourceCodeCleanerUtils.emptyStringsLookingLikeComments(content);
 

--- a/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/lang/vb/VisualBasicAnalyzer.java
+++ b/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/lang/vb/VisualBasicAnalyzer.java
@@ -53,7 +53,7 @@ public class VisualBasicAnalyzer extends LanguageAnalyzer {
         content = SourceCodeCleanerUtils.emptyLinesMatchingPattern("[ ]*End [A-Z][a-z]+[ ]*", content);
         content = SourceCodeCleanerUtils.emptyLinesMatchingPattern("[ ]*Imports .*", content);
 
-        return SourceCodeCleanerUtils.cleanSingeLineCommentsAndEmptyLines(content, Arrays.asList("'", "REM "));
+        return SourceCodeCleanerUtils.cleanSingleLineCommentsAndEmptyLines(content, Arrays.asList("'", "REM "));
     }
 
     @Override


### PR DESCRIPTION
### Renaming Suggestion of Method Names to Make Them More Descriptive
---
**Description**
---

We have developed a tool (**NameSpotter**) for identifying non-descriptive method names, and using this tool we find a non-descriptive method name in your repository:

```java
/* Non-descriptive Method Name in codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/cleaners/SourceCodeCleanerUtils.java*/
    public static CleanedContent cleanSingeLineCommentsAndEmptyLines(String content, List<String> singleLineCommentStarts) {
        content = SourceCodeCleanerUtils.normalizeLineEnds(content);
        content = SourceCodeCleanerUtils.emptyStringsLookingLikeComments(content);

        for (String singleLineCommentStart : singleLineCommentStarts) {
            content = CommentsCleanerUtils.cleanLineComments(content, singleLineCommentStart);
        }

        return SourceCodeCleanerUtils.cleanEmptyLinesWithLineIndexes(content);
    }
```

We consider "cleanSingeLineCommentsAndEmptyLines" as non-descriptive because it contains a typo, i.e., "Singe" should be "Single". 

We have corrected them (including all the occurrences in other file) and submitted a pull request.

Do you agree with the judgment? 

- If not, could you please leave your valuable opinion?

- If you do agree, the relevant modification has been submitted as a PR, and thanks for your precious time to consider it.