### PR TITLE
Migrate docker base images from deprecated openjdk to eclipse-temurin

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build
-FROM maven:3.8.4-openjdk-11-slim AS build
+FROM maven:3.9.9-eclipse-temurin-11 AS build
 
 WORKDIR /build
 COPY . .
@@ -8,7 +8,7 @@ COPY . .
 RUN mvn clean install -DskipTests
 
 # Stage 2: Setup the runtime environment
-FROM openjdk:11-jre-slim
+FROM eclipse-temurin:11-jre-noble
 
 # Install Graphviz (required for running Sokrates)
 RUN apt-get update && \


### PR DESCRIPTION
This change involves migrating the deprecated docker base images to images maintained by eclipse-temurin