### PR TITLE
Fix Kotlin interface methods to correctly report 0 LOC

### DIFF
--- a/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/lang/kotlin/KotlinHeuristicUnitsExtractor.java
+++ b/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/lang/kotlin/KotlinHeuristicUnitsExtractor.java
@@ -7,6 +7,8 @@ package nl.obren.sokrates.sourcecode.lang.kotlin;
 import nl.obren.sokrates.common.utils.RegexUtils;
 import nl.obren.sokrates.sourcecode.units.CStyleHeuristicUnitsExtractor;
 
+import java.util.List;
+
 public class KotlinHeuristicUnitsExtractor extends CStyleHeuristicUnitsExtractor {
     public KotlinHeuristicUnitsExtractor() {
         super.setExtractRecursively(true);
@@ -27,5 +29,89 @@ public class KotlinHeuristicUnitsExtractor extends CStyleHeuristicUnitsExtractor
         return RegexUtils.matchesEntirely("[ ]*init[ ]*{[ ]*", line);
     }
 
+    public List<nl.obren.sokrates.sourcecode.units.UnitInfo> extractUnits(nl.obren.sokrates.sourcecode.SourceFile sourceFile) {
+        // Get the basic unit extraction from parent
+        List<nl.obren.sokrates.sourcecode.units.UnitInfo> units = super.extractUnits(sourceFile);
+        
+        // Post-process to adjust unit LOC for interface methods
+        return adjustUnitLocForInterfaceMethods(units, sourceFile);
+    }
+    
+    private List<nl.obren.sokrates.sourcecode.units.UnitInfo> adjustUnitLocForInterfaceMethods(
+            List<nl.obren.sokrates.sourcecode.units.UnitInfo> units, 
+            nl.obren.sokrates.sourcecode.SourceFile sourceFile) {
+        
+        List<String> lines = sourceFile.getLines();
+        List<nl.obren.sokrates.sourcecode.units.UnitInfo> adjustedUnits = new java.util.ArrayList<>();
+        
+        for (nl.obren.sokrates.sourcecode.units.UnitInfo unit : units) {
+            if (isInterfaceMethodUnit(unit, lines)) {
+                // Create a new unit with 0 LOC for interface methods
+                nl.obren.sokrates.sourcecode.units.UnitInfo interfaceUnit = new nl.obren.sokrates.sourcecode.units.UnitInfo();
+                interfaceUnit.setShortName(unit.getShortName());
+                interfaceUnit.setStartLine(unit.getStartLine());
+                interfaceUnit.setEndLine(unit.getStartLine()); // Same as start line
+                interfaceUnit.setSourceFile(unit.getSourceFile());
+                interfaceUnit.setLinesOfCode(0); // Interface methods have 0 LOC
+                interfaceUnit.setMcCabeIndex(1); // Default complexity
+                interfaceUnit.setNumberOfParameters(unit.getNumberOfParameters());
+                interfaceUnit.setBody("");
+                interfaceUnit.setCleanedBody("");
+                adjustedUnits.add(interfaceUnit);
+            } else {
+                adjustedUnits.add(unit); // Keep regular methods unchanged
+            }
+        }
+        
+        return adjustedUnits;
+    }
+    
+    private boolean isInterfaceMethodUnit(nl.obren.sokrates.sourcecode.units.UnitInfo unit, List<String> lines) {
+        // Check if this unit represents an interface method by examining the source lines
+        int startLine = unit.getStartLine() - 1; // Convert to 0-based index
+        if (startLine >= 0 && startLine < lines.size()) {
+            // Look for the function signature and check if it has no opening brace
+            for (int i = startLine; i < Math.min(lines.size(), startLine + unit.getLinesOfCode()); i++) {
+                String line = lines.get(i).trim();
+                if (line.contains("fun ")) {
+                    boolean hasImpl = hasImplementation(lines, i);
+                    return !hasImpl;
+                }
+            }
+        }
+        return false;
+    }
+    
+    private boolean hasImplementation(List<String> lines, int functionLineIndex) {
+        // Check if this function has an implementation (opening brace)
+        String currentLine = lines.get(functionLineIndex).trim();
+        
+        // If the opening brace is on the same line as the function signature
+        if (currentLine.contains("{")) {
+            return true;
+        }
+        
+        // Look at the next few lines for an opening brace
+        for (int i = functionLineIndex + 1; i < Math.min(lines.size(), functionLineIndex + 5); i++) {
+            String line = lines.get(i).trim();
+            
+            // Skip empty lines and annotations
+            if (line.isEmpty() || line.startsWith("@")) {
+                continue;
+            }
+            
+            // If we encounter another function signature or end of interface, stop looking
+            if (line.contains("fun ") || line.equals("}")) {
+                break;
+            }
+            
+            // Found opening brace
+            if (line.contains("{")) {
+                return true;
+            }
+        }
+        
+        return false; // No implementation found
+    }
 
 }

--- a/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/lang/kotlin/KotlinAnalyzerTest.java
+++ b/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/lang/kotlin/KotlinAnalyzerTest.java
@@ -62,4 +62,31 @@ public class KotlinAnalyzerTest {
         assertEquals(7, units.get(1).getStartLine());
         assertEquals(11, units.get(1).getEndLine());
     }
+
+    @Test
+    public void extractUnitsFromInterfaceMethods() {
+        String code = KotlinExampleFragments.INTERFACE_METHODS_FRAGMENT;
+
+        KotlinAnalyzer analyzer = new KotlinAnalyzer();
+
+        List<UnitInfo> units = analyzer.extractUnits(new SourceFile(new File(""), code));
+
+        // Should extract 4 units: 3 interface methods (0 LOC each) + 1 implemented method
+        assertEquals(4, units.size());
+
+        // Interface methods should have 0 lines of code
+        assertEquals("fun findAllByPropertyId()", units.get(0).getShortName());
+        assertEquals(0, units.get(0).getLinesOfCode());
+
+        assertEquals("fun findAllByPropertyIdAndUnitId()", units.get(1).getShortName());
+        assertEquals(0, units.get(1).getLinesOfCode());
+
+        assertEquals("fun simpleMethod()", units.get(2).getShortName());
+        assertEquals(0, units.get(2).getLinesOfCode());
+
+        // Implemented method should have > 0 lines of code
+        assertEquals("fun implementedMethod()", units.get(3).getShortName());
+        assertEquals(3, units.get(3).getLinesOfCode());
+    }
+
 }

--- a/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/lang/kotlin/KotlinExampleFragments.java
+++ b/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/lang/kotlin/KotlinExampleFragments.java
@@ -34,4 +34,32 @@ public class KotlinExampleFragments {
             "for (arg in args) {\n" +
             "println(arg)";
 
+    // Interface methods fragment for testing
+    public static String INTERFACE_METHODS_FRAGMENT = "interface PropertyRepository {\n" +
+            "    fun findAllByPropertyId(\n" +
+            "        @Param(\"propertyId\") propertyId: String\n" +
+            "    ): List<Property>\n" +
+            "\n" +
+            "    @Query(\n" +
+            "        \"\"\"\n" +
+            "        select u\n" +
+            "            from Unit u\n" +
+            "            where u.property.id = :propertyId\n" +
+            "              and upper(u.identifiers.id) = upper(:unitId)\n" +
+            "              and u.deleted = false\n" +
+            "            order by u.identifiers.id asc, u.id \n" +
+            "        \"\"\"\n" +
+            "    )\n" +
+            "    fun findAllByPropertyIdAndUnitId(\n" +
+            "        @Param(\"propertyId\") propertyId: String,\n" +
+            "        @Param(\"unitId\") unitId: String\n" +
+            "    ): List<Unit>\n" +
+            "\n" +
+            "    fun simpleMethod(param: String): String\n" +
+            "\n" +
+            "    fun implementedMethod(param: String): String {\n" +
+            "        return \"result\"\n" +
+            "    }\n" +
+            "}";
+
 }


### PR DESCRIPTION
Interface methods in Kotlin (.kt files) without implementation were not properly recognized, causing the analysis to treat the entire file as one unit instead of individual methods with 0 lines of code.

Changes:
- Override extractUnits() in KotlinHeuristicUnitsExtractor to post-process units
- Add adjustUnitLocForInterfaceMethods() to detect interface methods without braces
- Set interface methods to 0 LOC while preserving implemented method analysis
- Add comprehensive test cases for interface method detection

Note: There is a separate issue where multi-line @Query(...) and other annotations are currently counted as 0 LOC even though they logically belong to the function. This should be addressed in a future improvement to determine whether annotations should contribute to unit size.

🤖 Generated with the help of [Claude Code](https://claude.ai/code)