### PR TITLE
Add backtick template literal normalization in unit duplication detection

### DIFF
--- a/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/units/CStyleHeuristicUnitsExtractor.java
+++ b/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/units/CStyleHeuristicUnitsExtractor.java
@@ -231,6 +231,7 @@ public class CStyleHeuristicUnitsExtractor {
         cleanedContent = cleanedContent.replaceAll("@\".*?\"", "\"\"");
         cleanedContent = cleanedContent.replaceAll("\".*?\"", "\"\"");
         cleanedContent = cleanedContent.replaceAll("'.*?'", "''");
+        cleanedContent = cleanedContent.replaceAll("`[^`]*`", "``");
         cleanedContent = cleanedContent.replaceAll("/.+?/", "\"\"");
         cleanedContent = cleanedContent.replace("://", ":/ /");
         cleanedContent = cleanedContent.replaceAll("[<].*?[>]", "");

--- a/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/units/CStyleHeuristicUnitsExtractorTest.java
+++ b/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/units/CStyleHeuristicUnitsExtractorTest.java
@@ -57,6 +57,26 @@ public class CStyleHeuristicUnitsExtractorTest {
     }
 
     @Test
+    public void cleanContentBacktickTemplateLiterals() throws Exception {
+        CStyleHeuristicUnitsExtractor unitParser = new CStyleHeuristicUnitsExtractor();
+
+        // Backtick template literals should be emptied
+        assertEquals("``", unitParser.extraCleanContent("`hello world`"));
+        assertEquals("``", unitParser.extraCleanContent("`${apiUrl}/alpha/${id}/upload`"));
+        assertEquals("``", unitParser.extraCleanContent("`${apiUrl}/beta/${id}/upload`"));
+
+        // After cleaning, template literals with different content produce the same result
+        String cleaned1 = unitParser.extraCleanContent("const url = `${apiUrl}/alpha/${site}/${customer}/upload`;");
+        String cleaned2 = unitParser.extraCleanContent("const url = `${apiUrl}/beta/${site}/${customer}/upload`;");
+        assertEquals(cleaned1, cleaned2);
+
+        // Template literal without slashes should also be normalized
+        String cleaned3 = unitParser.extraCleanContent("const msg = `Processing alpha`;");
+        String cleaned4 = unitParser.extraCleanContent("const msg = `Processing beta`;");
+        assertEquals(cleaned3, cleaned4);
+    }
+
+    @Test
     public void getEndOfUnitBodyIndex1() throws Exception {
         CStyleHeuristicUnitsExtractor unitParser = new CStyleHeuristicUnitsExtractor();
 


### PR DESCRIPTION
Fix for [Unit duplication detection: backtick template literals not normalized #66 ](https://github.com/zeljkoobrenovic/sokrates/issues/66).

extraCleanContent() normalizes double-quoted and single-quoted string contents before comparing units for duplication, but backtick template literals were not handled. This caused inconsistent behavior where template literal differences were only masked accidentally by the regex literal pattern (/.+?/).