### PR TITLE
Deploy build artifacts to S3 and invalidate CloudFront

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -14,11 +14,19 @@ phases:
   post_build:
     commands:
       - echo Build completed on `date`
-      - mkdir builds
       - cp cli/target/cli-1.0-jar-with-dependencies.jar sokrates.jar
       - cp codeexplorer/target/codeexplorer-1.0-jar-with-dependencies.jar sokrates-explorer.jar
       - cp sokrates.jar sokrates-LATEST.jar
       - cp sokrates-explorer.jar sokrates-explorer-LATEST.jar
+      # Upload the artifacts to S3 explicitly here, so the CloudFront invalidation below always
+      # runs AFTER a completed upload (CodeBuild's own artifacts:: upload happens only once this
+      # phase finishes, which would otherwise race the invalidation and re-cache stale jars).
+      - aws s3 cp sokrates.jar                 s3://sokrates-artifacts/builds/sokrates.jar                 --only-show-errors
+      - aws s3 cp sokrates-explorer.jar        s3://sokrates-artifacts/builds/sokrates-explorer.jar        --only-show-errors
+      - aws s3 cp sokrates-LATEST.jar          s3://sokrates-artifacts/builds/sokrates-LATEST.jar          --only-show-errors
+      - aws s3 cp sokrates-explorer-LATEST.jar s3://sokrates-artifacts/builds/sokrates-explorer-LATEST.jar --only-show-errors
+      # Invalidate the public CloudFront distribution that exposes the build artifacts.
+      - aws cloudfront create-invalidation --distribution-id E31A2TZX8192JW --paths "/*"
 artifacts:
   files:
     - sokrates.jar


### PR DESCRIPTION
## What

After the CodeBuild build produces the jars, `post_build` now:

1. Uploads all four jars explicitly to `s3://sokrates-artifacts/builds/`.
2. Invalidates the public CloudFront distribution `E31A2TZX8192JW` that serves them (`/*`).

## Why the explicit S3 upload

CodeBuild's own `artifacts::` upload happens only **after** `post_build` finishes — there's no post-artifact hook in buildspec 0.2. Putting the invalidation in `post_build` while relying on that mechanism would fire the invalidation **before** the new jars land in S3, re-caching stale content. Uploading explicitly in `post_build` (before the invalidation) makes the order deterministic: upload → invalidate.

Also dropped the unused `mkdir builds` line.

## ⚠️ Requires IAM permissions on the CodeBuild service role

The build will fail at the new steps unless the role has:
- `s3:PutObject` on `arn:aws:s3:::sokrates-artifacts/builds/*`
- `cloudfront:CreateInvalidation` on `arn:aws:cloudfront::<account-id>:distribution/E31A2TZX8192JW`

The `artifacts:` block is left in place (harmless; still feeds the CodeBuild-configured artifact location / any CodePipeline stage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)