### PR TITLE
Detect the encoding from a BOM instead of always decoding as UTF-8

### DIFF
--- a/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/SourceCodeEncoding.java
+++ b/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/SourceCodeEncoding.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2021 Željko Obrenović. All rights reserved.
+ */
+
+package nl.obren.sokrates.sourcecode;
+
+import org.apache.commons.io.ByteOrderMark;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.input.BOMInputStream;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.List;
+
+/**
+ * Reads source code, detecting the character encoding from a leading byte order mark (BOM) instead of
+ * assuming UTF-8.
+ *
+ * <p>Decoding every file as UTF-8 silently corrupts UTF-16 sources: line breaks still survive, so
+ * lines-of-code counts look normal while every unit-extraction regex fails to match, yielding zero units
+ * and no complexity metrics. Windows tooling produces UTF-16 by default in several common cases (for
+ * example SQL Server Management Studio exports .sql as UTF-16 LE with a BOM), so this is not a rare
+ * situation.
+ *
+ * <p>Only a BOM is used to select the charset - no statistical charset guessing. A file without a BOM
+ * is decoded as UTF-8 exactly as before, so existing UTF-8 and ASCII code bases are unaffected: same
+ * bytes in, same strings out.
+ *
+ * <p>The BOM itself is never part of the returned text. Leaving a U+FEFF at the start of the content
+ * would break regular expressions anchored with {@code ^} on the first line.
+ */
+public class SourceCodeEncoding {
+    // UTF-32 is deliberately absent: it is not encountered in practice for source code, and its BOMs
+    // start with the UTF-16 BOM byte sequences, so including it would require careful ordering here
+    // for no practical gain.
+    private static final ByteOrderMark[] SUPPORTED_BOMS = {
+            ByteOrderMark.UTF_8, ByteOrderMark.UTF_16LE, ByteOrderMark.UTF_16BE
+    };
+
+    private static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
+
+    private SourceCodeEncoding() {
+    }
+
+    /**
+     * Decodes source code bytes, honouring a leading BOM and falling back to UTF-8 when there is none.
+     *
+     * @param bytes the raw bytes of a source file; an empty array yields an empty string
+     * @return the decoded text, without any BOM character
+     */
+    public static String decode(byte[] bytes) {
+        try (InputStream inputStream = new ByteArrayInputStream(bytes)) {
+            return read(inputStream);
+        } catch (IOException e) {
+            // Unreachable: a ByteArrayInputStream performs no I/O. Rethrown unchecked so that callers
+            // holding bytes in memory are not forced to handle an exception that cannot occur.
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    /**
+     * Reads a source file, honouring a leading BOM and falling back to UTF-8 when there is none.
+     *
+     * @return the file's text, without any BOM character
+     */
+    public static String read(File file) throws IOException {
+        try (InputStream inputStream = Files.newInputStream(file.toPath())) {
+            return read(inputStream);
+        }
+    }
+
+    /**
+     * Reads a source file as lines, honouring a leading BOM and falling back to UTF-8 when there is none.
+     *
+     * <p>Line splitting matches {@code FileUtils.readLines}: lines are separated by any of LF, CRLF or
+     * CR, the terminators are not included, and a trailing terminator does not produce a final empty
+     * line.
+     *
+     * @return the file's lines, with any BOM character removed from the first line
+     */
+    public static List<String> readLines(File file) throws IOException {
+        try (InputStream inputStream = Files.newInputStream(file.toPath())) {
+            return readLines(inputStream);
+        }
+    }
+
+    private static String read(InputStream source) throws IOException {
+        try (BOMInputStream inputStream = bomInputStream(source)) {
+            return IOUtils.toString(inputStream, charsetOf(inputStream));
+        }
+    }
+
+    private static List<String> readLines(InputStream source) throws IOException {
+        try (BOMInputStream inputStream = bomInputStream(source)) {
+            return IOUtils.readLines(inputStream, charsetOf(inputStream));
+        }
+    }
+
+    private static BOMInputStream bomInputStream(InputStream source) throws IOException {
+        return BOMInputStream.builder()
+                .setInputStream(source)
+                // Exclude the BOM from the stream so it never reaches the decoded text.
+                .setInclude(false)
+                .setByteOrderMarks(SUPPORTED_BOMS)
+                .get();
+    }
+
+    /**
+     * Resolves the charset from the detected BOM. Reading the BOM buffers the first bytes of the stream
+     * without consuming them, so this must be called before the stream is read.
+     */
+    private static Charset charsetOf(BOMInputStream inputStream) throws IOException {
+        String charsetName = inputStream.getBOMCharsetName();
+        return charsetName != null ? Charset.forName(charsetName) : DEFAULT_CHARSET;
+    }
+}

--- a/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/SourceFile.java
+++ b/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/SourceFile.java
@@ -10,14 +10,12 @@ import nl.obren.sokrates.sourcecode.cleaners.SourceCodeCleanerUtils;
 import nl.obren.sokrates.sourcecode.filehistory.FileModificationHistory;
 import nl.obren.sokrates.sourcecode.lang.LanguageAnalyzer;
 import nl.obren.sokrates.sourcecode.lang.LanguageAnalyzerFactory;
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -175,7 +173,7 @@ public class SourceFile {
     public String getContent() {
         try {
             File file = getFile();
-            return StringUtils.isNotBlank(content) ? content : file != null ? FileUtils.readFileToString(file, StandardCharsets.UTF_8) : "";
+            return StringUtils.isNotBlank(content) ? content : file != null ? SourceCodeEncoding.read(file) : "";
         } catch (IOException e) {
             LOG.debug(e);
         }
@@ -193,7 +191,7 @@ public class SourceFile {
         try {
             List<String> lines = StringUtils.isNotBlank(content)
                     ? SourceCodeCleanerUtils.splitInLines(content) : getFile() != null
-                    ? FileUtils.readLines(getFile(), StandardCharsets.UTF_8) : new ArrayList<>();
+                    ? SourceCodeEncoding.readLines(getFile()) : new ArrayList<>();
             return lines;
         } catch (IOException e) {
             LOG.debug(e);

--- a/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/SourceCodeEncodingTest.java
+++ b/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/SourceCodeEncodingTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2021 Željko Obrenović. All rights reserved.
+ */
+
+package nl.obren.sokrates.sourcecode;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+
+import static java.nio.charset.StandardCharsets.UTF_16BE;
+import static java.nio.charset.StandardCharsets.UTF_16LE;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+
+public class SourceCodeEncodingTest {
+    private static final byte[] BOM_UTF_8 = {(byte) 0xEF, (byte) 0xBB, (byte) 0xBF};
+    private static final byte[] BOM_UTF_16_LE = {(byte) 0xFF, (byte) 0xFE};
+    private static final byte[] BOM_UTF_16_BE = {(byte) 0xFE, (byte) 0xFF};
+
+    private static final String SAMPLE = "public class Foo {\n    void bar() {\n    }\n}";
+
+    @Test
+    public void decodesUtf8WithoutBom() {
+        assertEquals(SAMPLE, SourceCodeEncoding.decode(SAMPLE.getBytes(UTF_8)));
+    }
+
+    @Test
+    public void decodesNonAsciiUtf8WithoutBom() {
+        // Guards the fallback path: a file with no BOM must still decode as UTF-8, multi-byte characters included.
+        String text = "// éü中文 🚀";
+
+        assertEquals(text, SourceCodeEncoding.decode(text.getBytes(UTF_8)));
+    }
+
+    @Test
+    public void stripsUtf8Bom() {
+        String decoded = SourceCodeEncoding.decode(concat(BOM_UTF_8, SAMPLE.getBytes(UTF_8)));
+
+        assertEquals(SAMPLE, decoded);
+        // An unstripped U+FEFF would break regexes anchored with '^' on the first line.
+        assertTrue(decoded.startsWith("public"));
+    }
+
+    @Test
+    public void decodesUtf16LittleEndianWithBom() {
+        assertEquals(SAMPLE, SourceCodeEncoding.decode(concat(BOM_UTF_16_LE, SAMPLE.getBytes(UTF_16LE))));
+    }
+
+    @Test
+    public void decodesUtf16BigEndianWithBom() {
+        assertEquals(SAMPLE, SourceCodeEncoding.decode(concat(BOM_UTF_16_BE, SAMPLE.getBytes(UTF_16BE))));
+    }
+
+    @Test
+    public void decodesEmptyInput() {
+        assertEquals("", SourceCodeEncoding.decode(new byte[0]));
+    }
+
+    @Test
+    public void decodesInputThatIsOnlyABom() {
+        assertEquals("", SourceCodeEncoding.decode(BOM_UTF_16_LE));
+    }
+
+    @Test
+    public void readsFileInEveryEncoding() throws IOException {
+        assertEquals(SAMPLE, SourceCodeEncoding.read(fileWith(SAMPLE.getBytes(UTF_8))));
+        assertEquals(SAMPLE, SourceCodeEncoding.read(fileWith(concat(BOM_UTF_8, SAMPLE.getBytes(UTF_8)))));
+        assertEquals(SAMPLE, SourceCodeEncoding.read(fileWith(concat(BOM_UTF_16_LE, SAMPLE.getBytes(UTF_16LE)))));
+        assertEquals(SAMPLE, SourceCodeEncoding.read(fileWith(concat(BOM_UTF_16_BE, SAMPLE.getBytes(UTF_16BE)))));
+    }
+
+    @Test
+    public void readsLinesInEveryEncoding() throws IOException {
+        List<String> expected = Arrays.asList("public class Foo {", "    void bar() {", "    }", "}");
+
+        assertEquals(expected, SourceCodeEncoding.readLines(fileWith(SAMPLE.getBytes(UTF_8))));
+        assertEquals(expected, SourceCodeEncoding.readLines(fileWith(concat(BOM_UTF_8, SAMPLE.getBytes(UTF_8)))));
+        assertEquals(expected, SourceCodeEncoding.readLines(fileWith(concat(BOM_UTF_16_LE, SAMPLE.getBytes(UTF_16LE)))));
+        assertEquals(expected, SourceCodeEncoding.readLines(fileWith(concat(BOM_UTF_16_BE, SAMPLE.getBytes(UTF_16BE)))));
+    }
+
+    @Test
+    public void readMatchesPreviousUtf8BehaviourWhenThereIsNoBom() throws IOException {
+        // The central compatibility guarantee: for files without a BOM - the overwhelming majority -
+        // this must return exactly what the previous hard-coded UTF-8 read returned.
+        for (String text : samplesWithVariedLineEndings()) {
+            File file = fileWith(text.getBytes(UTF_8));
+
+            assertEquals(FileUtils.readFileToString(file, UTF_8), SourceCodeEncoding.read(file));
+        }
+    }
+
+    @Test
+    public void readLinesMatchesPreviousUtf8BehaviourWhenThereIsNoBom() throws IOException {
+        // Same guarantee for the line-based path, including CRLF, CR, blank lines and a trailing newline.
+        for (String text : samplesWithVariedLineEndings()) {
+            File file = fileWith(text.getBytes(UTF_8));
+
+            assertEquals(FileUtils.readLines(file, UTF_8), SourceCodeEncoding.readLines(file));
+        }
+    }
+
+    private List<String> samplesWithVariedLineEndings() {
+        return Arrays.asList(
+                SAMPLE,
+                "a\r\nb\r\nc",
+                "a\rb\rc",
+                "a\n\n\nb",
+                "trailing newline\n",
+                "no newline at all",
+                "",
+                "// éü中文");
+    }
+
+    private static byte[] concat(byte[] first, byte[] second) {
+        byte[] result = Arrays.copyOf(first, first.length + second.length);
+        System.arraycopy(second, 0, result, first.length, second.length);
+        return result;
+    }
+
+    private File fileWith(byte[] bytes) throws IOException {
+        Path file = Files.createTempFile("sokrates-encoding-", ".txt");
+        Files.write(file, bytes);
+        File asFile = file.toFile();
+        asFile.deleteOnExit();
+        return asFile;
+    }
+}

--- a/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/SourceFileEncodingTest.java
+++ b/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/SourceFileEncodingTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2021 Željko Obrenović. All rights reserved.
+ */
+
+package nl.obren.sokrates.sourcecode;
+
+import nl.obren.sokrates.common.utils.ProgressFeedback;
+import nl.obren.sokrates.sourcecode.units.UnitInfo;
+import nl.obren.sokrates.sourcecode.units.UnitsExtractor;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.nio.charset.StandardCharsets.UTF_16BE;
+import static java.nio.charset.StandardCharsets.UTF_16LE;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static junit.framework.TestCase.assertEquals;
+
+/**
+ * End-to-end cover for the encoding fix: a source file must produce the same analysis regardless of the
+ * encoding it happens to be stored in.
+ *
+ * <p>Uses C# because Windows tooling is where UTF-16 sources actually come from, and because it exercises
+ * a language analyzer other than the Java one.
+ */
+public class SourceFileEncodingTest {
+    private static final byte[] BOM_UTF_8 = {(byte) 0xEF, (byte) 0xBB, (byte) 0xBF};
+    private static final byte[] BOM_UTF_16_LE = {(byte) 0xFF, (byte) 0xFE};
+    private static final byte[] BOM_UTF_16_BE = {(byte) 0xFE, (byte) 0xFF};
+
+    private static final String CSHARP_SOURCE = "using System;\n"
+            + "namespace Demo {\n"
+            + "    public class Calculator {\n"
+            + "        public int Compute(int a, int b) {\n"
+            + "            if (a > 0 && b > 0) { return a + b; }\n"
+            + "            return 0;\n"
+            + "        }\n"
+            + "        public int Other(int x) {\n"
+            + "            for (int i = 0; i < x; i++) { x += i; }\n"
+            + "            return x;\n"
+            + "        }\n"
+            + "    }\n"
+            + "}\n";
+
+    @Test
+    public void getContentHonoursTheByteOrderMark() throws IOException {
+        for (byte[] bytes : theSameSourceInEveryEncoding()) {
+            assertEquals(CSHARP_SOURCE, new SourceFile(sourceFileWith(bytes)).getContent());
+        }
+    }
+
+    @Test
+    public void getLinesHonoursTheByteOrderMark() throws IOException {
+        List<String> expected = Arrays.asList(CSHARP_SOURCE.split("\n"));
+
+        for (byte[] bytes : theSameSourceInEveryEncoding()) {
+            assertEquals(expected, new SourceFile(sourceFileWith(bytes)).getLines());
+        }
+    }
+
+    @Test
+    public void linesOfCodeAreIdenticalAcrossEncodings() throws IOException {
+        for (byte[] bytes : theSameSourceInEveryEncoding()) {
+            SourceFile sourceFile = new SourceFile(sourceFileWith(bytes));
+            sourceFile.setLinesOfCodeFromContent();
+
+            assertEquals(13, sourceFile.getLinesOfCode());
+        }
+    }
+
+    @Test
+    public void unitsAndComplexityAreIdenticalAcrossEncodings() throws IOException {
+        // Before the fix, the UTF-16 variants yielded zero units while lines of code still counted
+        // normally - a silent loss of every complexity metric.
+        for (byte[] bytes : theSameSourceInEveryEncoding()) {
+            List<UnitInfo> units = unitsOf(sourceFileWith(bytes));
+
+            assertEquals(Arrays.asList("public int Compute()", "public int Other()"), namesOf(units));
+            assertEquals(Arrays.asList(3, 2), complexitiesOf(units));
+        }
+    }
+
+    private List<byte[]> theSameSourceInEveryEncoding() {
+        return Arrays.asList(
+                CSHARP_SOURCE.getBytes(UTF_8),
+                concat(BOM_UTF_8, CSHARP_SOURCE.getBytes(UTF_8)),
+                concat(BOM_UTF_16_LE, CSHARP_SOURCE.getBytes(UTF_16LE)),
+                concat(BOM_UTF_16_BE, CSHARP_SOURCE.getBytes(UTF_16BE)));
+    }
+
+    private List<UnitInfo> unitsOf(File file) {
+        return new UnitsExtractor().getUnits(Collections.singletonList(new SourceFile(file)), new ProgressFeedback());
+    }
+
+    private List<String> namesOf(List<UnitInfo> units) {
+        return units.stream().map(UnitInfo::getShortName).collect(Collectors.toList());
+    }
+
+    private List<Integer> complexitiesOf(List<UnitInfo> units) {
+        return units.stream().map(UnitInfo::getMcCabeIndex).collect(Collectors.toList());
+    }
+
+    private static byte[] concat(byte[] first, byte[] second) {
+        byte[] result = Arrays.copyOf(first, first.length + second.length);
+        System.arraycopy(second, 0, result, first.length, second.length);
+        return result;
+    }
+
+    private File sourceFileWith(byte[] bytes) throws IOException {
+        Path file = Files.createTempFile("sokrates-encoding-", ".cs");
+        Files.write(file, bytes);
+        File asFile = file.toFile();
+        asFile.deleteOnExit();
+        return asFile;
+    }
+}


### PR DESCRIPTION
SourceFile decoded every file as UTF-8, which silently corrupts UTF-16 sources. The failure is invisible rather than loud: line breaks still survive, so lines-of-code counts look completely normal while every unit-extraction regex fails to match. The result is zero units and no complexity metrics for the affected files, and a report that looks healthy rather than broken.

This is not a rare situation. Windows tooling produces UTF-16 by default in several common cases - SQL Server Management Studio exports .sql as UTF-16 LE with a BOM - and it affects any language, not one in particular. Every unit in an affected file is lost, so a large export can silently leave a whole code base with no complexity data at all.

Add SourceCodeEncoding, which selects the charset from a leading byte order mark (UTF-8, UTF-16 LE, UTF-16 BE) and falls back to UTF-8 when there is none, and use it for both of SourceFile's read paths. The BOM is excluded from the returned text, so a leading U+FEFF can no longer break regexes anchored with '^' on the first line.

Compatibility: a file without a BOM decodes exactly as before - same bytes in, same strings out - so existing UTF-8 and ASCII code bases are unaffected. Behaviour changes only for files that currently decode to garbage. Two tests assert this equivalence against the previous implementation directly, across LF, CRLF, CR, blank lines, a trailing newline and multi-byte characters.

No new dependency: commons-io's BOMInputStream is already on the classpath, and it inspects only the first bytes of a stream that is read in full anyway.

Verified: with SourceFile reverted, the end-to-end test fails with 'expected:<[public int Compute(), public int Other()]> but was:<[]>' - while the lines-of-code assertion still passes, which is precisely the silent failure mode being fixed.

Fixes #101 