### PR TITLE
Fix unit line numbers in the Python, Ruby and Visual Basic extractors

### DIFF
--- a/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/lang/python/PythonHeuristicUnitsExtractor.java
+++ b/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/lang/python/PythonHeuristicUnitsExtractor.java
@@ -51,6 +51,10 @@ public class PythonHeuristicUnitsExtractor {
                     }
                     UnitInfo unit = new UnitInfo();
                     unit.setSourceFile(sourceFile);
+                    // Mapped back to file lines: lineIndex counts cleaned lines, which is not the same
+                    // thing once comments have been stripped.
+                    unit.setStartLine(cleanedContent.getFileLineIndexes().get(lineIndex) + 1);
+                    unit.setEndLine(cleanedContent.getFileLineIndexes().get(endOfUnitBodyIndex) + 1);
                     unit.setLinesOfCode(endOfUnitBodyIndex - lineIndex + 1);
                     unit.setCleanedBody(body.toString());
                     unit.setBody(body.toString());

--- a/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/lang/ruby/RubyHeuristicUnitsExtractor.java
+++ b/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/lang/ruby/RubyHeuristicUnitsExtractor.java
@@ -23,7 +23,10 @@ public class RubyHeuristicUnitsExtractor {
             String trimmedLine = line.trim();
             if (trimmedLine.startsWith("def ") && !trimmedLine.endsWith(" end") && !trimmedLine.endsWith(";end")) {
                 UnitInfo unit = getUnitInfo(sourceFile, line, trimmedLine);
-                unit.setStartLine(i);
+                // i is a 0-based index into the lines; unit line numbers are 1-based. The end line
+                // below needs no such adjustment: the loop that finds it leaves i one past the unit's
+                // last line, which is already the 1-based number of that line.
+                unit.setStartLine(i + 1);
 
                 String unitEnd = line.substring(0, line.indexOf("def ")) + "end";
                 int loc = 0;

--- a/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/lang/vb/VisualBasicHeuristicUnitsExtractor.java
+++ b/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/lang/vb/VisualBasicHeuristicUnitsExtractor.java
@@ -65,8 +65,9 @@ public class VisualBasicHeuristicUnitsExtractor {
         unit.setSourceFile(sourceFile);
         unit.setShortName(line.trim());
         unit.setLinesOfCode(loc);
-        unit.setStartLine(startLine);
-        unit.setEndLine(endLine);
+        // Both arrive as 0-based indexes into the line list; unit line numbers are 1-based.
+        unit.setStartLine(startLine + 1);
+        unit.setEndLine(endLine + 1);
         unit.setBody(body);
         unit.setCleanedBody(cleanedBody);
 

--- a/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/units/UnitInfo.java
+++ b/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/units/UnitInfo.java
@@ -52,6 +52,15 @@ public class UnitInfo {
         this.sourceFile = sourceFile;
     }
 
+    /**
+     * The unit's first line in the source file, <b>1-based</b>, or 0 when the extractor could not
+     * place it.
+     *
+     * <p>Extractors that work from cleaned content must map back through
+     * {@code CleanedContent.getFileLineIndexes()} before adding 1, since a cleaned line index is not a
+     * file line once comments have been stripped. Reports link source fragments by these numbers, so an
+     * off-by-one sends a reader to the wrong line.
+     */
     public int getStartLine() {
         return startLine;
     }
@@ -60,6 +69,7 @@ public class UnitInfo {
         this.startLine = startLine;
     }
 
+    /** The unit's last line in the source file, <b>1-based and inclusive</b>. See {@link #getStartLine}. */
     public int getEndLine() {
         return endLine;
     }

--- a/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/units/UnitLineNumbersTest.java
+++ b/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/units/UnitLineNumbersTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2021 Željko Obrenović. All rights reserved.
+ */
+
+package nl.obren.sokrates.sourcecode.units;
+
+import nl.obren.sokrates.sourcecode.SourceFile;
+import nl.obren.sokrates.sourcecode.lang.LanguageAnalyzerFactory;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit line numbers are 1-based file lines, and this holds every language's extractor to that.
+ *
+ * <p>The convention was previously folklore: most extractors followed it, a few did not, and nothing
+ * said which was right. Reports link source fragments by these numbers, so an extractor that reports
+ * a 0-based index sends readers to the line above the unit, and one that reports nothing sends them
+ * to line 0.
+ *
+ * <p>Each fixture puts a <b>comment on line 1</b>. That is the whole trick: a correct extractor can
+ * never report a first unit starting at line 1, so an off-by-one and a missing line number both show
+ * up as a failure here rather than as a slightly wrong link in a report.
+ */
+public class UnitLineNumbersTest {
+
+    @Test
+    public void javaUnitsAreOnOneBasedFileLines() {
+        assertFirstUnit("a.java", "// comment\nclass A {\n  int one() {\n    return 1;\n  }\n}\n", 3, 5);
+    }
+
+    @Test
+    public void javaScriptUnitsAreOnOneBasedFileLines() {
+        assertFirstUnit("a.js", "// comment\nfunction one() {\n  return 1;\n}\n", 2, 4);
+    }
+
+    @Test
+    public void pythonUnitsAreOnOneBasedFileLines() {
+        assertFirstUnit("a.py", "# comment\ndef alpha(x):\n    return x\n", 2, 3);
+    }
+
+    @Test
+    public void rubyUnitsAreOnOneBasedFileLines() {
+        assertFirstUnit("a.rb", "# comment\nclass Foo\n  def bar(x)\n    x + 1\n  end\nend\n", 3, 5);
+    }
+
+    @Test
+    public void visualBasicUnitsAreOnOneBasedFileLines() {
+        assertFirstUnit("a.vb", "' comment\nModule M\n    Sub Alpha()\n        Dim x = 1\n    End Sub\nEnd Module\n", 3, 5);
+    }
+
+    @Test
+    public void luaUnitsAreOnOneBasedFileLines() {
+        assertFirstUnit("a.lua", "-- comment\nfunction alpha(x)\n  return x\nend\n", 2, 4);
+    }
+
+    @Test
+    public void juliaUnitsAreOnOneBasedFileLines() {
+        assertFirstUnit("a.jl", "# comment\nfunction alpha(x)\n    return x\nend\n", 2, 4);
+    }
+
+    /**
+     * The property every extractor must satisfy, stated without naming a specific line: whatever the
+     * language, a unit that follows a comment cannot begin on line 1, and cannot end before it starts.
+     * A new extractor added without its own case above is still worth holding to this.
+     */
+    @Test
+    public void noExtractorPlacesAUnitBeforeTheFileStarts() {
+        String[][] fixtures = {
+                {"a.java", "// comment\nclass A {\n  int one() {\n    return 1;\n  }\n}\n"},
+                {"a.js", "// comment\nfunction one() {\n  return 1;\n}\n"},
+                {"a.py", "# comment\ndef alpha(x):\n    return x\n"},
+                {"a.rb", "# comment\nclass Foo\n  def bar(x)\n    x + 1\n  end\nend\n"},
+                {"a.vb", "' comment\nModule M\n    Sub Alpha()\n        Dim x = 1\n    End Sub\nEnd Module\n"},
+                {"a.lua", "-- comment\nfunction alpha(x)\n  return x\nend\n"},
+                {"a.jl", "# comment\nfunction alpha(x)\n    return x\nend\n"},
+        };
+
+        for (String[] fixture : fixtures) {
+            List<UnitInfo> units = extractUnits(fixture[0], fixture[1]);
+            assertFalse(fixture[0] + ": expected at least one unit", units.isEmpty());
+            for (UnitInfo unit : units) {
+                assertTrue(fixture[0] + ": unit \"" + unit.getShortName().trim() + "\" starts at line "
+                                + unit.getStartLine() + ", but line 1 is a comment",
+                        unit.getStartLine() >= 2);
+                assertTrue(fixture[0] + ": unit \"" + unit.getShortName().trim() + "\" ends at line "
+                                + unit.getEndLine() + ", before it starts at " + unit.getStartLine(),
+                        unit.getEndLine() >= unit.getStartLine());
+            }
+        }
+    }
+
+    private void assertFirstUnit(String fileName, String content, int expectedStartLine, int expectedEndLine) {
+        List<UnitInfo> units = extractUnits(fileName, content);
+
+        assertFalse(fileName + ": expected at least one unit", units.isEmpty());
+        UnitInfo first = units.get(0);
+        assertEquals(fileName + ": start line", expectedStartLine, first.getStartLine());
+        assertEquals(fileName + ": end line", expectedEndLine, first.getEndLine());
+    }
+
+    private List<UnitInfo> extractUnits(String fileName, String content) {
+        SourceFile sourceFile = new SourceFile(new File(fileName), content);
+        return LanguageAnalyzerFactory.getInstance().getLanguageAnalyzer(sourceFile).extractUnits(sourceFile);
+    }
+}


### PR DESCRIPTION
`UnitInfo.startLine` and `endLine` are consumed as 1-based file line numbers. Most extractors set them that way; three do not, and no test enforced the convention, so it was folklore rather than a contract.

## What a user sees today

A small Python project analysed with `generateReports`. Every unit in the project:

```
analysisResults.json -> unitsAnalysisResults.longestUnits
  def main()           startLine=0 endLine=0 loc=36 mcCabe=8
  def chat_stream()    startLine=0 endLine=0 loc=25 mcCabe=6
  def chat_streaming() startLine=0 endLine=0 loc=16 mcCabe=3
```

Lines of code and McCabe are correct — only the position is lost, which is why this is easy to miss: every number on the page looks plausible. It reaches everything downstream in the same run. `data.zip -> text/units.txt` reads `start line: 0` for every unit, and `src/viewer.html -> fragments/longest_unit.json` carries `from=0 to=0`, so every **Longest Units** and **Most Complex Units** link opens the source viewer at line 0.

Ruby and Visual Basic are not zeroed but shifted: their units link one line above themselves, to the line before the signature.

Same project with this change, against the real positions of those functions:

```
unit                   file                        real  after fix
def main()             src/interactive_chat.py       25         25
def chat_stream()      src/lmstudio_client.py        36         36
def chat_streaming()   src/openai_sdk_call.py        38         38
def chat()             src/lmstudio_client.py        19         19
def chat()             src/openai_sdk_call.py        25         25
def list_models()      src/lmstudio_client.py        65         65
```

`def main()` becomes `from=25 to=67` in the viewer fragment, and `text/units.txt` reads `start line: 25`.

## The defects

| Language | Where | What |
| --- | --- | --- |
| Python | `PythonHeuristicUnitsExtractor.extractUnits` | never calls `setStartLine`/`setEndLine`, so every unit stays at `0-0` |
| Ruby | `RubyHeuristicUnitsExtractor:26` | `setStartLine(i)` with `i` a 0-based index |
| Visual Basic | `VisualBasicHeuristicUnitsExtractor:46,68-69` | the 0-based loop index is passed as both start and end |

Measured with a control: the same unit pushed further down the file by five comment lines. The Ruby and Visual Basic errors stay constant at `-1`, so these are plain 0-based file lines rather than an index into cleaned content that has had lines removed. Python's value stays pinned at `0` however far down the unit sits.

```
java    pad=0  true 2-4  reported 2-4    java    pad=5  true 7-9  reported 7-9   <- control
python  pad=0  true 1-2  reported 0-0    python  pad=5  true 6-7  reported 0-0
ruby    pad=0  true 2-4  reported 1-4    ruby    pad=5  true 7-9  reported 6-9
vb      pad=0  true 2-4  reported 1-3    vb      pad=5  true 7-9  reported 6-8
```

## The change

1. **Python** sets both lines, mapped through `CleanedContent.getFileLineIndexes()` — the same mapping `CStyleHeuristicUnitsExtractor:92-93` uses, and already computed a few lines above for the unit body.
2. **Ruby** gets `+1` on the start line **only**. Its end line is already correct: the loop that finds it leaves `i` one past the unit's last line, which is that line's 1-based number. Adding `+1` to both would fix the start and break the end.
3. **Visual Basic** gets `+1` on both.
4. `UnitInfo` documents the convention on the getters — 1-based, `0` when the extractor could not place the unit — including the requirement to map through `getFileLineIndexes()` when working from cleaned content.
5. `UnitLineNumbersTest` pins the convention across languages. Every fixture puts a **comment on line 1**, so a correct extractor can never report a first unit starting at line 1. Reverting any of the three fixes makes it fail by language name.

Full `codeanalyzer` suite passes (499 tests). No existing test asserted the old values — of the language test folders, 10 of 30 assert unit line numbers, and these three are among the 20 that do not, which is why this survived.

## Two notes

**`AdabasNaturalAnalyzer` has a related but different problem, left out of this PR** because it needs its own investigation: its subroutine start lines are pinned at 1 regardless of their real position, its end lines are never set, and `extractClassUnit` appends a file-level unit with no position at all — so one file can carry both placed and unplaced units. Happy to follow up separately.

**The `0` sentinel is kept and documented rather than changed.** In a 1-based scheme 0 can never be a real line, so it is unambiguous, and it is already what the affected extractors emit — a nullable `Integer` would instead turn `"startLine": 0` into `"startLine": null` in `analysisResults.json` for every affected unit and push null-handling onto every consumer. If you would prefer `-1`, a nullable type, or a `hasLineNumbers()` predicate alongside it, any of those is a small follow-up — it affects every consumer of `UnitInfo`, so it seemed better to raise than to settle inside a bug fix.