### PR TITLE
Cover the Windows export shape in the encoding tests

### DIFF
--- a/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/SourceFileEncodingTest.java
+++ b/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/SourceFileEncodingTest.java
@@ -87,6 +87,26 @@ public class SourceFileEncodingTest {
         }
     }
 
+    @Test
+    public void aWindowsExportIsAnalysedWithoutBeingReEncodedFirst() throws IOException {
+        // UTF-16 LE with a BOM *and* CRLF: the shape Windows tooling actually emits, and the one
+        // combination not covered above, where the encoding varies but the line endings stay LF.
+        byte[] export = concat(BOM_UTF_16_LE, CSHARP_SOURCE.replace("\n", "\r\n").getBytes(UTF_16LE));
+        File file = sourceFileWith(export);
+
+        assertEquals(Arrays.asList(CSHARP_SOURCE.split("\n")), new SourceFile(file).getLines());
+
+        SourceFile sourceFile = new SourceFile(file);
+        sourceFile.setLinesOfCodeFromContent();
+        assertEquals(13, sourceFile.getLinesOfCode());
+
+        // Units are asserted beside the lines of code in one method for the reason the class javadoc
+        // gives: a wrong decode still counts lines normally and only empties the unit list.
+        List<UnitInfo> units = unitsOf(file);
+        assertEquals(Arrays.asList("public int Compute()", "public int Other()"), namesOf(units));
+        assertEquals(Arrays.asList(3, 2), complexitiesOf(units));
+    }
+
     private List<byte[]> theSameSourceInEveryEncoding() {
         return Arrays.asList(
                 CSHARP_SOURCE.getBytes(UTF_8),


### PR DESCRIPTION
Follow-up to #100. The tests it added vary the encoding but keep LF line endings throughout, and SourceCodeEncodingTest covers CRLF only for files with no BOM. So the one combination Windows tooling actually emits - UTF-16 LE with a BOM *and* CRLF - is exercised nowhere, although it is the shape #100 was written for.

Both halves have to work on that file: the BOM selects the charset, and the carriage returns must then not reach the line text. The new test asserts the units beside the lines of code in a single method because the failure mode is the one #100 describes - a wrong decode still counts lines normally and only empties the unit list.

Load-bearing check: narrowing SUPPORTED_BOMS to UTF-8 fails four of the five tests in the class, the new one included. The survivor is linesOfCodeAreIdenticalAcrossEncodings, which is the point.

Test only, no production code changes.