### PR TITLE
Document analyzerOverrides in the configuration manual

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -152,8 +152,44 @@ Switches and risk thresholds for the analysis itself. Common keys:
 | `conditionalComplexityThresholds` | `{low:5, medium:10, high:25, veryHigh:50}` | Risk bands for unit complexity. |
 | `fileAgeThresholds` / `fileUpdateFrequencyThresholds` | (see source) | Risk bands for history metrics. |
 
-Each `*Thresholds` is an object `{ "low", "medium", "high", "veryHigh" }`. `analyzerOverrides`
-can force a specific language analyzer for files matching given filters.
+Each `*Thresholds` is an object `{ "low", "medium", "high", "veryHigh" }`.
+
+#### `analyzerOverrides`
+
+By default the language analyzer is chosen by file extension. `analyzerOverrides` forces a
+different analyzer for files matching given filters — useful when one extension covers several
+dialects, so the extension alone does not identify the language.
+
+```json
+"analyzerOverrides": [
+  {
+    "analyzer": "plsql",
+    "filters": [
+      { "pathPattern": ".*/db/packages/.*[.]sql", "note": "Oracle PL/SQL, not generic SQL" }
+    ]
+  }
+]
+```
+
+- **`analyzer`** is the *extension key* the analyzer is registered under in
+  `LanguageAnalyzerFactory` — `"plsql"`, `"cs"`, `"java"`, … — not a class name. A key that is
+  not registered is not reported as an error, and the matched files fall through to the generic
+  `DefaultLanguageAnalyzer` rather than to the analyzer their extension would have chosen. A typo
+  here therefore leaves the files analysed *less* well than no override at all, so check the key
+  against `LanguageAnalyzerFactory` when a language's metrics look unexpectedly flat.
+- **`filters`** are ordinary source-file filters (`pathPattern`, `contentPattern`, `exception`,
+  `note`). A file is overridden when at least one filter matches it and no `exception` filter
+  matches it, whatever their order in the list.
+- **`pathPattern` must match the *whole* path**, so prefix it with `.*` — `.*[.]sql` matches,
+  `[.]sql` does not. Both `/` and `\` separators are tried, so one pattern works on either
+  platform.
+- **`contentPattern` must likewise match a whole *line***, not appear somewhere in one. To route
+  by a keyword anywhere in the file, wrap it: `".*\\bPACKAGE BODY\\b.*"`.
+
+In the example above, `.sql` files under `db/packages/` are analysed as PL/SQL while every other
+`.sql` file still uses the generic SQL analyzer. This is the preferred way to handle dialect
+specific files that carry a generic extension: it lives in configuration, survives re-exports,
+and does not require renaming source files.
 
 ### `fileHistoryAnalysis`
 


### PR DESCRIPTION
The manual gives analyzerOverrides one sentence - "can force a specific language analyzer for files matching given filters" - which says what it is for but not enough to use it. Three of the answers a reader needs next are traps, so they are stated explicitly.

Every claim added was checked against the real factory, with a PL/SQL override on a .sql file:

  path ".*/db/packages/.*[.]sql"  -> PlSqlAnalyzer
  path "[.]sql"                   -> SqlAnalyzer   (no leading .*)
  content "PACKAGE BODY"          -> SqlAnalyzer   (not a whole line)
  content ".*\bPACKAGE BODY\b.*"  -> PlSqlAnalyzer
  exception filter after  a match -> SqlAnalyzer
  exception filter before a match -> SqlAnalyzer
  analyzer "no-such-analyzer"     -> DefaultLanguageAnalyzer

That is: patterns match entirely rather than partially - for paths, and again for content, where the unit of matching is a whole line rather than the file; exception filters disqualify a file wherever they sit in the list; and an unregistered analyzer key is silent, dropping files to DefaultLanguageAnalyzer instead of to the analyzer their extension would have chosen.

The example uses plsql because it is a real registered key and .sql really is shared between dialects, so it is the case the feature exists for.

Documentation only.