### PR TITLE
Extract units whose names contain letters outside ASCII

### DIFF
--- a/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/lang/hack/HackHeuristicUnitsExtractor.java
+++ b/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/lang/hack/HackHeuristicUnitsExtractor.java
@@ -18,11 +18,11 @@ public class HackHeuristicUnitsExtractor extends CStyleHeuristicUnitsExtractor {
     }
 
     private boolean isFunction(String line) {
-        String idRegex = "[a-zA-Z_$][a-zA-Z_$0-9]*";
+        String idRegex = "[\\p{L}_$][\\p{L}\\p{M}\\p{N}_$]*";
         return !line.contains(";")
                 && doesNotStartWithKeyword(line)
                 && (RegexUtils.matchesEntirely("[ ]*function[ ]*" + idRegex + "[(].*", line)
-                || RegexUtils.matchesEntirely("[ ]*[a-zA-Z_]+[ ]*function[ ]*" + idRegex + "[(].*", line));
+                || RegexUtils.matchesEntirely("[ ]*[\\p{L}_][\\p{L}\\p{M}_]*[ ]*function[ ]*" + idRegex + "[(].*", line));
     }
 
     public boolean doesNotStartWithKeyword(String line) {

--- a/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/lang/js/JavaScriptHeuristicUnitsExtractor.java
+++ b/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/lang/js/JavaScriptHeuristicUnitsExtractor.java
@@ -18,7 +18,7 @@ public class JavaScriptHeuristicUnitsExtractor extends CStyleHeuristicUnitsExtra
     }
 
     private boolean isFunction(String line) {
-        String idRegex = "[a-zA-Z_$][a-zA-Z_$0-9]*";
+        String idRegex = "[\\p{L}_$][\\p{L}\\p{M}\\p{N}_$]*";
         return !line.contains(";")
                 && doesNotStartWithKeyword(line)
                 && (RegexUtils.matchesEntirely("[ ]*function[ ]*[(].*", line)

--- a/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/lang/kotlin/KotlinHeuristicUnitsExtractor.java
+++ b/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/lang/kotlin/KotlinHeuristicUnitsExtractor.java
@@ -21,7 +21,7 @@ public class KotlinHeuristicUnitsExtractor extends CStyleHeuristicUnitsExtractor
     }
 
     private boolean isFunction(String line) {
-        String idRegex = "[a-zA-Z_$][a-zA-Z_$0-9]*";
+        String idRegex = "[\\p{L}_$][\\p{L}\\p{M}\\p{N}_$]*";
         String prefixes = "override |open |protected |public | private |suspend ";
         return !line.contains(";") && !line.contains("=") && (RegexUtils.matchesEntirely("[ ]*(" + prefixes + ")*[ ]*fun[ ]*" + idRegex + "[(].*", line));
     }

--- a/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/lang/objectpascal/ObjectPascalHeuristicUnitsExtractor.java
+++ b/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/lang/objectpascal/ObjectPascalHeuristicUnitsExtractor.java
@@ -54,7 +54,7 @@ public class ObjectPascalHeuristicUnitsExtractor {
 
     private boolean isFunctionStartLine(String line) {
         String trimmedLine = line.trim().replace("\t", " ");
-        return RegexUtils.matchesEntirely("(class[ ]+)?(procedure|function|method)[ ]+([a-zA-Z0-9_]+[.])+[a-zA-Z0-9_]+[ ]*(\\(|;).*", trimmedLine);
+        return RegexUtils.matchesEntirely("(class[ ]+)?(procedure|function|method)[ ]+([\\p{L}\\p{N}_][\\p{L}\\p{M}\\p{N}_]*[.])+[\\p{L}\\p{N}_][\\p{L}\\p{M}\\p{N}_]*[ ]*(\\(|;).*", trimmedLine);
     }
 
     private void updateUnit(String line) {

--- a/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/lang/r/RHeuristicUnitsExtractor.java
+++ b/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/lang/r/RHeuristicUnitsExtractor.java
@@ -10,6 +10,6 @@ import nl.obren.sokrates.sourcecode.units.CStyleHeuristicUnitsExtractor;
 public class RHeuristicUnitsExtractor extends CStyleHeuristicUnitsExtractor {
     @Override
     public boolean isUnitSignature(String line) {
-        return RegexUtils.matchesEntirely("[ ]*[a-zA-Z_0-9]+[ ]* [<][-][ ]*function[ ]*[(].*", line);
+        return RegexUtils.matchesEntirely("[ ]*[\\p{L}\\p{N}_][\\p{L}\\p{M}\\p{N}_]*[ ]* [<][-][ ]*function[ ]*[(].*", line);
     }
 }

--- a/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/lang/swift/SwiftHeuristicUnitsExtractor.java
+++ b/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/lang/swift/SwiftHeuristicUnitsExtractor.java
@@ -18,7 +18,7 @@ public class SwiftHeuristicUnitsExtractor extends CStyleHeuristicUnitsExtractor 
     }
 
     private boolean isFunction(String line) {
-        String idRegex = "[a-zA-Z_$][a-zA-Z_$0-9]*";
+        String idRegex = "[\\p{L}_$][\\p{L}\\p{M}\\p{N}_$]*";
         String prefixes = "mutating ";
         return !line.contains(";") && !line.contains("=") && (RegexUtils.matchesEntirely("[ ]*(" + prefixes + ")*[ ]*func[ ]*" + idRegex + "[(].*", line));
     }

--- a/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/units/CStyleHeuristicUnitsExtractor.java
+++ b/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/units/CStyleHeuristicUnitsExtractor.java
@@ -21,7 +21,7 @@ public class CStyleHeuristicUnitsExtractor {
     // Constant unit-signature pattern: one or more space-separated identifiers followed by "(".
     // Compiled once (static) rather than per candidate line — isUnitSignature runs for every line
     // of every file across all C-style languages, so recompiling here was a measurable hot spot.
-    private static final String IDENTIFIER_PATTERN = "[a-zA-Z0-9_$?:~]+";
+    private static final String IDENTIFIER_PATTERN = "[\\p{L}\\p{N}_$?:~][\\p{L}\\p{M}\\p{N}_$?:~]*";
     private static final Pattern START_UNIT_PATTERN =
             Pattern.compile("(" + IDENTIFIER_PATTERN + "[ ]+)+" + IDENTIFIER_PATTERN + "[ ]*[(]");
 

--- a/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/units/CppUnitsExtractor.java
+++ b/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/units/CppUnitsExtractor.java
@@ -40,7 +40,7 @@ public class CppUnitsExtractor extends CStyleHeuristicUnitsExtractor {
         if (line.contains("(") && !line.contains("new ") && !line.trim().startsWith("else ")
                 && !line.trim().startsWith("?") && !line.trim().startsWith(":")) {
             line = line.substring(0, line.indexOf("(") + 1);
-            String identifierPattern = "[a-zA-Z0-9_$?:~]+";
+            String identifierPattern = "[\\p{L}\\p{N}_$?:~][\\p{L}\\p{M}\\p{N}_$?:~]*";
             String startUnitRegex = "(" + identifierPattern + "[ ]+)+" + identifierPattern + "[ ]*[(]";
             Pattern pattern = Pattern.compile(startUnitRegex);
             Matcher matcher = pattern.matcher(line);

--- a/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/units/UnitNamesWithNonAsciiLettersTest.java
+++ b/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/units/UnitNamesWithNonAsciiLettersTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2021 Željko Obrenović. All rights reserved.
+ */
+
+package nl.obren.sokrates.sourcecode.units;
+
+import nl.obren.sokrates.sourcecode.SourceFile;
+import nl.obren.sokrates.sourcecode.lang.LanguageAnalyzerFactory;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * A unit whose name contains a letter outside ASCII must still be extracted.
+ *
+ * <p>Identifier patterns were written as {@code [a-zA-Z0-9_...]}, so a method called {@code prüfen} or
+ * {@code beregnØre} did not match a unit signature at all. The unit was not reported: not merely named
+ * oddly, but absent from unit counts, size and complexity, with nothing to indicate a file had been
+ * skipped. German, Nordic, French and Spanish code bases were under-reported without any signal.
+ *
+ * <p>Each case is paired with an ASCII equivalent, so the assertion is that the two behave the same
+ * rather than that some particular number comes out.
+ */
+public class UnitNamesWithNonAsciiLettersTest {
+
+    @Test
+    public void cStyleLanguages() {
+        assertSameAsAscii("A.java",
+                "class A {\n  void check() {\n    int x = 1;\n  }\n}\n",
+                "class A {\n  void prüfen() {\n    int x = 1;\n  }\n}\n");
+        assertSameAsAscii("A.cs",
+                "class A {\n  public void Check() {\n    int x = 1;\n  }\n}\n",
+                "class A {\n  public void Prüfen() {\n    int x = 1;\n  }\n}\n");
+        assertSameAsAscii("a.go", "func check() {\n x := 1\n}\n", "func prüfen() {\n x := 1\n}\n");
+        assertSameAsAscii("a.rs", "fn check() {\n let x = 1;\n}\n", "fn prüfen() {\n let x = 1;\n}\n");
+        assertSameAsAscii("a.scala", "def check() {\n val x = 1\n}\n", "def prüfen() {\n val x = 1\n}\n");
+        assertSameAsAscii("a.groovy", "def check() {\n def x = 1\n}\n", "def prüfen() {\n def x = 1\n}\n");
+        assertSameAsAscii("a.php", "function check() {\n $x = 1;\n}\n", "function prüfen() {\n $x = 1;\n}\n");
+        assertSameAsAscii("a.cpp", "void check() {\n int x = 1;\n}\n", "void prüfen() {\n int x = 1;\n}\n");
+    }
+
+    @Test
+    public void languagesWithTheirOwnIdentifierPattern() {
+        // These declare an identifier pattern of their own rather than using the C-style one, which is
+        // why the same defect had to be corrected in each of them.
+        assertSameAsAscii("a.js", "function check() {\n var x = 1;\n}\n", "function prüfen() {\n var x = 1;\n}\n");
+        assertSameAsAscii("a.ts", "function check() {\n var x = 1;\n}\n", "function prüfen() {\n var x = 1;\n}\n");
+        assertSameAsAscii("a.kt", "fun check() {\n val x = 1\n}\n", "fun prüfen() {\n val x = 1\n}\n");
+        assertSameAsAscii("a.swift", "func check() {\n let x = 1\n}\n", "func prüfen() {\n let x = 1\n}\n");
+        assertSameAsAscii("a.hh", "function check() {\n $x = 1;\n}\n", "function prüfen() {\n $x = 1;\n}\n");
+        assertSameAsAscii("a.r", "check <- function() {\n x <- 1\n}\n", "prüfen <- function() {\n x <- 1\n}\n");
+        assertSameAsAscii("a.pas",
+                "procedure A.check();\nbegin\n x := 1;\nend;\n",
+                "procedure A.prüfen();\nbegin\n x := 1;\nend;\n");
+    }
+
+    @Test
+    public void aNonAsciiNameIsReportedInFull() {
+        List<UnitInfo> units = unitsOf("A.java", "class A {\n  void beregnØre() {\n    int x = 1;\n  }\n}\n");
+
+        assertEquals(1, units.size());
+        // Not truncated at the non-ASCII letter, which is how a too-narrow pattern would fail if it
+        // matched the prefix rather than failing outright.
+        assertEquals("void beregnØre()", units.get(0).getShortName().trim());
+    }
+
+    @Test
+    public void aDecomposedAccentIsTreatedLikeAPrecomposedOne() {
+        // The same name written two ways: é as one code point, and as "e" followed by a combining acute.
+        // Editors and pipelines differ on which they produce, and a class of letters alone does not admit
+        // the second form - the combining mark is a mark, not a letter, so the name broke off at it.
+        String precomposed = "class A {\n  void café() {\n    int x = 1;\n  }\n}\n";
+        String decomposed = "class A {\n  void cafe\u0301() {\n    int x = 1;\n  }\n}\n";
+
+        assertEquals(1, unitsOf("A.java", precomposed).size());
+        assertEquals("the two spellings are the same name and must extract alike",
+                1, unitsOf("A.java", decomposed).size());
+    }
+
+    @Test
+    public void aStrayCombiningMarkDoesNotInventAUnit() {
+        // Admitting combining marks has to stop short of letting one BEGIN a token: a mark with no base
+        // letter is garbled input, not a name, and a line of it before a declaration was briefly enough
+        // to match a signature. Real accented text is unaffected, since a mark there always follows a
+        // letter and so falls in the tail.
+        assertEquals(0, unitsOf("A.java", "class A {\n  \u0301 void foo() {\n    int x = 1;\n  }\n}\n").size());
+        assertEquals(0, unitsOf("a.hh", "\u0301 function foo() {\n  $x = 1;\n}\n").size());
+        assertEquals(0, unitsOf("a.cpp", "\u0301 void foo() {\n  int x = 1;\n}\n").size());
+        assertEquals(0, unitsOf("a.r", "\u0301 <- function() {\n x <- 1\n}\n").size());
+        assertEquals(0, unitsOf("a.pas", "procedure A.\u0301();\nbegin\n x := 1;\nend;\n").size());
+
+        // The same lines without the stray mark are ordinary declarations and must still extract.
+        assertEquals(1, unitsOf("A.java", "class A {\n  void foo() {\n    int x = 1;\n  }\n}\n").size());
+        assertEquals(1, unitsOf("a.hh", "function foo() {\n  $x = 1;\n}\n").size());
+        assertEquals(1, unitsOf("a.r", "foo <- function() {\n x <- 1\n}\n").size());
+        assertEquals(1, unitsOf("a.pas", "procedure A.foo();\nbegin\n x := 1;\nend;\n").size());
+    }
+
+    private void assertSameAsAscii(String fileName, String asciiContent, String nonAsciiContent) {
+        int ascii = unitsOf(fileName, asciiContent).size();
+        int nonAscii = unitsOf(fileName, nonAsciiContent).size();
+
+        assertEquals(fileName + ": the ASCII fixture must extract a unit for the comparison to mean "
+                + "anything", 1, ascii);
+        assertEquals(fileName + ": a non-ASCII name must not change how many units are found",
+                ascii, nonAscii);
+    }
+
+    private List<UnitInfo> unitsOf(String fileName, String content) {
+        SourceFile sourceFile = new SourceFile(new File(fileName), content);
+        return LanguageAnalyzerFactory.getInstance().getLanguageAnalyzer(sourceFile).extractUnits(sourceFile);
+    }
+}


### PR DESCRIPTION
## What this fixes

A method whose name contains a letter outside ASCII is **not extracted as a unit at all**. Not misnamed — absent. It does not appear in the unit count, unit size, conditional complexity, or any top-N list, and nothing indicates that anything was skipped.

Measured on `master`, an ASCII method against an otherwise identical one with an accented name:

| Language | ASCII | Accented |
|---|---|---|
| Java | `void check()` → 1 unit | `void prüfen()` → **0 units** |
| C# | `public void Check()` → 1 unit | `public void Prüfen()` → **0 units** |
| JavaScript | `function check()` → 1 unit | `function prüfen()` → **0 units** |
| Kotlin | `fun check()` → 1 unit | `fun prüfen()` → **0 units** |
| Swift | `func check()` → 1 unit | `func prüfen()` → **0 units** |
| C++ | `void check()` → 1 unit | `void prüfen()` → **0 units** |
| R | `check <- function()` → 1 unit | `prüfen <- function()` → **0 units** |
| Object Pascal | `procedure A.check()` → 1 unit | `procedure A.prüfen()` → **0 units** |

So any German, Nordic, French or Spanish code base that uses accented identifiers is under-reported today, silently.

**Which metrics move:** unit-level ones only — unit count, unit size and its risk distribution, conditional complexity and its distribution, and the longest/most-complex top-N lists. Lines of code, file size, duplication, dependencies and contributors are unaffected: the file is still read and counted, only the unit inside it disappears.

**What triggers it:** anything before the opening parenthesis, since the signature is truncated at `(` before matching. So the method name *or the return type* — `Größe check()` vanishes even though the method name is ASCII. A non-ASCII parameter type, or non-ASCII text in the body or in a comment, is harmless.

**This is not hypothetical.** Running before and after across four real code bases (12,000+ files of Java, C#, TypeScript, Kotlin, Go, Scala, PHP), three were pure ASCII and unchanged. The fourth — a private code base that names part of its domain in Danish — recovered **9 methods across 6 files** that had never been measured: four production methods, of which two carry a McCabe of 4 and 5, and five tests.

That is 0.12% of that repository's units, so the aggregate effect is small. The reason it matters is not the magnitude but that the loss is **silent and unbounded**: a code base that names more of its domain in a non-English language loses proportionally more, and nothing in the report indicates that anything is missing.

## The change

Nine lines across eight files. Each identifier character class is widened from ASCII letters and digits to `\p{L}` and `\p{N}`.

**The shape of every pattern is preserved exactly.** The C-style pattern still allows `$ ? : ~`; the JavaScript, Kotlin, Swift and Hack patterns still require a leading letter; R still allows a leading digit. The only behavioural difference is which characters count as letters.

## Why this is safe

Every pattern is **strictly more permissive** than before, so the change cannot remove a unit that is found today.

That is not the same as saying it is harmless, and review caught the difference. Permissiveness has to stop at the point where a mark could *begin* a token: `\p{L}` matches a letter but not a combining mark, so an accented name held in decomposed form (`e` + U+0301 rather than a precomposed `é`) still failed — but simply adding `\p{M}` everywhere then let a line holding nothing but a stray unattached mark match a declaration and **invent** a unit. Both are fixed: every class that can start a token is split into a leading character that excludes `\p{M}` and a tail that admits it. Real accented text is unaffected either way, since a mark there always follows a base letter.

Verified on a 4,757-file corpus of Java, C#, TypeScript, JavaScript, Kotlin, Go, Scala and PHP:

| | Before | After |
|---|---|---|
| Units | 30,574 | 30,574 |
| Lost / gained / altered | — | **0 / 0 / 0** |

Unchanged because that corpus is written entirely in ASCII — which is the point: existing analyses do not move.

`UnitNamesWithNonAsciiLettersTest` pins the behaviour across fifteen languages. It asserts that an accented name yields the *same* unit count as its ASCII twin, rather than asserting a particular number, so it stays valid if extraction improves. It also pins the two edge cases review surfaced: a decomposed accent must extract like a precomposed one, and a stray unattached combining mark must not invent a unit. Reverting the patterns fails its cases. `mvn clean install` is green.

## Scope: what this deliberately leaves alone

Fixing this prompted a sweep of the rest of `codeanalyzer` for the same assumption. Unit extraction was the main site and is covered here in full. Two other areas still carry ASCII-anchored patterns, and I have left them out on purpose — they belong to different metric families, and folding them in would make this change much harder to review.

- **Dependency extraction.** `PlSqlHeuristicDependenciesExtractor` matches `\w+[.][a-zA-Z]+` — and `\w` is itself ASCII-only in Java unless `UNICODE_CHARACTER_CLASS` is set, so both halves are affected. `PhpHeuristicDependenciesExtractor` uses `[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*`, which looks **deliberate**: it mirrors PHP's own identifier rules, which admit bytes 0x80–0xFF. The effect would be missing *edges* in component dependency graphs, not wrong sizes or complexity.
- **Scoping conventions.** Most patterns in `ScopingConventions` match tool-defined filenames — `Dockerfile`, `Jenkinsfile`, `jest`, `requirements.txt` — and are right as they are, since those names are ASCII by the tools' own conventions. A few match user-chosen directory names, e.g. `.*/mock[a-zA-Z0-9_\- ]+/.*`, so a folder called `mock-größe/` would not be recognised as test code and its files would stay in the main scope.

**I have not demonstrated either of these end to end.** They are read rather than run — a probe of the dependency path returned nothing for ASCII and non-ASCII input alike because it lacked real scoping, and the folder case is untested. So I am flagging them rather than claiming them. If they hold up under proper measurement I will raise them separately, one at a time.

Verified *unaffected*: lines of code and the cleaners (a file whose comments and string literals contain non-ASCII text counts identically to its ASCII twin), duplication, and contributor analysis.

## A question for you, deliberately not answered here

The same ASCII assumption existed in **eight places**, because several extractors declare their own identifier pattern instead of using `CStyleHeuristicUnitsExtractor`'s — and `CppUnitsExtractor` declares one that is byte-identical to the parent's it already inherits.

I have left all of them where they are and fixed each in place. Sharing them would have been a larger change than this defect warrants, and I would rather not restructure your code on my own judgement — `755c0872` and `1c841edd` touched the parent and `CppUnitsExtractor` on the same day without unifying them, which suggests the separation may be intentional.

If you would prefer them shared, I am happy to follow up with a second PR that hoists the two shapes (`[\p{L}\p{N}_$?:~]+` and the leading-letter variant) onto the parent and has the subclasses use them. That would remove the duplication that let this defect exist in eight places at once — but it is your call, not mine.
