### PR TITLE
Add a Microsoft T-SQL analyzer

### DIFF
--- a/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/lang/LanguageAnalyzerFactory.java
+++ b/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/lang/LanguageAnalyzerFactory.java
@@ -48,6 +48,7 @@ import nl.obren.sokrates.sourcecode.lang.sql.SqlAnalyzer;
 import nl.obren.sokrates.sourcecode.lang.swift.SwiftAnalyzer;
 import nl.obren.sokrates.sourcecode.lang.thrift.ThriftAnalyzer;
 import nl.obren.sokrates.sourcecode.lang.ts.TypeScriptAnalyzer;
+import nl.obren.sokrates.sourcecode.lang.tsql.TSqlAnalyzer;
 import nl.obren.sokrates.sourcecode.lang.vb.VisualBasicAnalyzer;
 import nl.obren.sokrates.sourcecode.lang.xml.XmlAnalyzer;
 import nl.obren.sokrates.sourcecode.lang.yaml.YamlAnalyzer;
@@ -223,6 +224,7 @@ public class LanguageAnalyzerFactory {
         analyzersMap.put("kts", KotlinAnalyzer.class);
 
         registerSql();
+        registerTSql();
 
         // shell
         analyzersMap.put("sh", ShellAnalyzer.class);
@@ -427,6 +429,10 @@ public class LanguageAnalyzerFactory {
         analyzersMap.put("pkb", PlSqlAnalyzer.class);
         analyzersMap.put("plb", PlSqlAnalyzer.class);
 
+    }
+
+    private void registerTSql() {
+        analyzersMap.put("tsql", TSqlAnalyzer.class);
     }
 
     private void registerJson() {

--- a/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/lang/tsql/TSqlAnalyzer.java
+++ b/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/lang/tsql/TSqlAnalyzer.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2021 Željko Obrenović. All rights reserved.
+ */
+
+package nl.obren.sokrates.sourcecode.lang.tsql;
+
+import nl.obren.sokrates.common.utils.ProgressFeedback;
+import nl.obren.sokrates.sourcecode.SourceFile;
+import nl.obren.sokrates.sourcecode.cleaners.CleanedContent;
+import nl.obren.sokrates.sourcecode.cleaners.CommentsAndEmptyLinesCleaner;
+import nl.obren.sokrates.sourcecode.cleaners.SourceCodeCleanerUtils;
+import nl.obren.sokrates.sourcecode.dependencies.DependenciesAnalysis;
+import nl.obren.sokrates.sourcecode.lang.LanguageAnalyzer;
+import nl.obren.sokrates.sourcecode.units.UnitInfo;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TSqlAnalyzer extends LanguageAnalyzer {
+    public TSqlAnalyzer() {
+    }
+
+    @Override
+    public CleanedContent cleanForLinesOfCodeCalculations(SourceFile sourceFile) {
+        return getCleaner().clean(sourceFile.getContent());
+    }
+
+    private CommentsAndEmptyLinesCleaner getCleaner() {
+        CommentsAndEmptyLinesCleaner cleaner = new CommentsAndEmptyLinesCleaner();
+
+        cleaner.addCommentBlockHelper("/*", "*/");
+        cleaner.addCommentBlockHelper("--", "\n");
+        cleaner.addStringBlockHelper("'", "\\");
+
+        return cleaner;
+    }
+
+    @Override
+    public CleanedContent cleanForDuplicationCalculations(SourceFile sourceFile) {
+        String content = getCleaner().cleanKeepEmptyLines(sourceFile.getContent());
+
+        content = SourceCodeCleanerUtils.trimLines(content);
+
+        return SourceCodeCleanerUtils.cleanEmptyLinesWithLineIndexes(content);
+    }
+
+    @Override
+    public List<UnitInfo> extractUnits(SourceFile sourceFile) {
+        return new TSqlHeuristicUnitsExtractor().extractUnits(sourceFile);
+    }
+
+    @Override
+    public DependenciesAnalysis extractDependencies(List<SourceFile> sourceFiles, ProgressFeedback progressFeedback) {
+        return new DependenciesAnalysis();
+    }
+
+    @Override
+    public List<String> getFeaturesDescription() {
+        List<String> features = new ArrayList<>();
+
+        features.add(FEATURE_ALL_STANDARD_ANALYSES);
+        features.add(FEATURE_ADVANCED_CODE_CLEANING);
+        features.add(FEATURE_UNIT_SIZE_ANALYSIS);
+        features.add(FEATURE_CONDITIONAL_COMPLEXITY_ANALYSIS);
+        features.add(FEATURE_NO_DEPENDENCIES_ANALYSIS);
+
+        return features;
+    }
+}

--- a/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/lang/tsql/TSqlAnalyzer.java
+++ b/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/lang/tsql/TSqlAnalyzer.java
@@ -30,7 +30,14 @@ public class TSqlAnalyzer extends LanguageAnalyzer {
 
         cleaner.addCommentBlockHelper("/*", "*/");
         cleaner.addCommentBlockHelper("--", "\n");
-        cleaner.addStringBlockHelper("'", "\\");
+        // T-SQL escapes a quote by doubling it ('it''s'), and a backslash is an ordinary character with
+        // no special meaning in a string. Naming backslash as the escape marker therefore misreads any
+        // literal ending in one - 'D:\Backups\', a routine path in a maintenance script - as an escaped
+        // quote, and the cleaner then runs on to the next quote in the file, or to the end of it. That
+        // silently drops every later procedure from unit extraction and undercounts lines of code for
+        // the whole remainder. Passing the quote as its own escape marker is what CodeBlockParser reads
+        // as the doubling rule.
+        cleaner.addStringBlockHelper("'", "'");
 
         return cleaner;
     }

--- a/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/lang/tsql/TSqlHeuristicUnitsExtractor.java
+++ b/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/lang/tsql/TSqlHeuristicUnitsExtractor.java
@@ -458,8 +458,16 @@ public class TSqlHeuristicUnitsExtractor {
             // depth, and the END handler above returns the moment depth reaches 0 with a BEGIN seen, so
             // that state can never survive to be tested here. The guard therefore did nothing when the
             // depth count was right, and suppressed the terminator precisely when it was wrong -
-            // turning any miscount into the unit swallowing every later procedure in the file. A
-            // CREATE PROCEDURE cannot legally span a GO, so ending here is never wrong for valid input.
+            // turning any miscount into the unit swallowing every later procedure in the file.
+            //
+            // It is not free. GO is client-side, so a bare GO *inside a multi-line string literal* is
+            // valid input, and the unit is cut short there - measured, a deployment helper holding
+            // 'PRINT 1\nGO\nPRINT 2' reports 4 lines instead of 8. The cost is bounded and visible: the
+            // unit's own size and complexity are understated, the truncation shows in its end line, and
+            // the following procedure is still extracted correctly. That is the trade against a
+            // miscount silently swallowing whole files, and multi-line literals are already a stated
+            // blind spot of this method - see the dynamic-SQL note above, which emptyStrings cannot
+            // reach either.
             if (k + 1 < lines.size() && GO_BATCH.matcher(lines.get(k + 1)).matches()) {
                 return k;
             }

--- a/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/lang/tsql/TSqlHeuristicUnitsExtractor.java
+++ b/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/lang/tsql/TSqlHeuristicUnitsExtractor.java
@@ -49,10 +49,13 @@ public class TSqlHeuristicUnitsExtractor {
             "\\bBEGIN\\b(?!\\s+(?:TRAN|TRANSACTION|DISTRIBUTED|TRY|CATCH|DIALOG|CONVERSATION))",
             KEYWORD_FLAGS);
 
-    // A delimited identifier. CASE, END, WHEN, IF and the rest are reserved words, so bracketing is the
-    // only way to use them as column names - which makes [Case], [End] and [When] the realistic form
-    // rather than an exotic one. They are masked out before any keyword is counted.
-    private static final Pattern BRACKETED_IDENTIFIER = Pattern.compile("\\[[^\\]]*\\]");
+    // A delimited identifier, in either of the two forms T-SQL accepts. CASE, END, WHEN, IF and the rest
+    // are reserved words, so delimiting is the only way to use them as column names, which makes
+    // [Case] and "End" realistic rather than exotic. Both forms escape their own closing delimiter by
+    // doubling it - [Value]]Begin] names Value]Begin - and the escape has to be understood here, since
+    // stopping at the first ] leaves the remainder of the name exposed to keyword matching.
+    private static final Pattern DELIMITED_IDENTIFIER = Pattern.compile(
+            "\\[(?:[^\\]]|\\]\\])*\\]|\"(?:[^\"]|\"\")*\"");
 
     // CASE opens a nested scope that must be closed by END before the outer BEGIN/END can close.
     private static final Pattern CASE_OPEN = Pattern.compile("\\bCASE\\b", KEYWORD_FLAGS);
@@ -207,7 +210,9 @@ public class TSqlHeuristicUnitsExtractor {
     private int findSignatureEnd(List<String> lines, int startIndex) {
         int parenDepth = 0;
         for (int k = startIndex; k < lines.size(); k++) {
-            String line = lines.get(k);
+            // Masked, so that an AS or BEGIN inside the object's own delimited name does not read as
+            // the end of the signature - which would cut the parameter list off before it is counted.
+            String line = maskDelimitedIdentifiers(lines.get(k));
             for (int c = 0; c < line.length(); c++) {
                 char ch = line.charAt(c);
                 if (ch == '(') parenDepth++;
@@ -459,7 +464,7 @@ public class TSqlHeuristicUnitsExtractor {
      * statement sequence, which only the batch separator or the end of the file terminates.
      */
     private boolean bodyOpensWithBegin(List<String> lines, int signatureEndIndex) {
-        String signatureLine = maskBracketedIdentifiers(lines.get(signatureEndIndex));
+        String signatureLine = maskDelimitedIdentifiers(lines.get(signatureEndIndex));
         Matcher as = AS_KEYWORD.matcher(signatureLine);
         if (as.find()) {
             String afterAs = signatureLine.substring(as.end());
@@ -475,7 +480,7 @@ public class TSqlHeuristicUnitsExtractor {
         }
 
         for (int k = signatureEndIndex + 1; k < lines.size(); k++) {
-            String line = maskBracketedIdentifiers(lines.get(k)).trim();
+            String line = maskDelimitedIdentifiers(lines.get(k)).trim();
             if (line.isEmpty()) {
                 continue;
             }
@@ -500,8 +505,8 @@ public class TSqlHeuristicUnitsExtractor {
     /**
      * Blanks out delimited identifiers, keeping the line the same length so token positions still line up.
      */
-    private String maskBracketedIdentifiers(String line) {
-        Matcher m = BRACKETED_IDENTIFIER.matcher(line);
+    private String maskDelimitedIdentifiers(String line) {
+        Matcher m = DELIMITED_IDENTIFIER.matcher(line);
         if (!m.find()) {
             return line;
         }
@@ -516,7 +521,7 @@ public class TSqlHeuristicUnitsExtractor {
     }
 
     private List<Token> scanBeginCaseEnd(String rawLine) {
-        String line = maskBracketedIdentifiers(rawLine);
+        String line = maskDelimitedIdentifiers(rawLine);
         List<Token> tokens = new ArrayList<>();
         Matcher beginMatcher = BEGIN_OPEN.matcher(line);
         while (beginMatcher.find()) {
@@ -551,7 +556,7 @@ public class TSqlHeuristicUnitsExtractor {
     }
 
     int computeMcCabeIndex(String cleanedBody) {
-        String body = maskBracketedIdentifiers(cleanedBody);
+        String body = maskDelimitedIdentifiers(cleanedBody);
         int mc = 1;
         for (Pattern p : MC_PATTERNS) {
             Matcher m = p.matcher(body);

--- a/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/lang/tsql/TSqlHeuristicUnitsExtractor.java
+++ b/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/lang/tsql/TSqlHeuristicUnitsExtractor.java
@@ -54,8 +54,13 @@ public class TSqlHeuristicUnitsExtractor {
     // [Case] and "End" realistic rather than exotic. Both forms escape their own closing delimiter by
     // doubling it - [Value]]Begin] names Value]Begin - and the escape has to be understood here, since
     // stopping at the first ] leaves the remainder of the name exposed to keyword matching.
+    // Written as an unrolled loop - a plain character class, then a group repeated once per doubled
+    // delimiter - rather than the natural (?:[^]]|]])* form. The natural form makes the JDK engine
+    // recurse once per character, so a long delimited identifier overflowed the stack with an Error
+    // rather than an Exception, which nothing upstream catches. Here the group iterates once per
+    // escape, of which real identifiers have none or one.
     private static final Pattern DELIMITED_IDENTIFIER = Pattern.compile(
-            "\\[(?:[^\\]]|\\]\\])*\\]|\"(?:[^\"]|\"\")*\"");
+            "\\[[^\\]]*(?:\\]\\][^\\]]*)*\\]|\"[^\"]*(?:\"\"[^\"]*)*\"");
 
     // CASE opens a nested scope that must be closed by END before the outer BEGIN/END can close.
     private static final Pattern CASE_OPEN = Pattern.compile("\\bCASE\\b", KEYWORD_FLAGS);

--- a/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/lang/tsql/TSqlHeuristicUnitsExtractor.java
+++ b/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/lang/tsql/TSqlHeuristicUnitsExtractor.java
@@ -415,8 +415,9 @@ public class TSqlHeuristicUnitsExtractor {
     /**
      * Walks BEGIN / CASE / END tokens in order of occurrence and tracks depth. BEGIN and CASE both open a
      * scope (+1); END closes either. The unit ends when depth returns to 0 at an END after at least one
-     * BEGIN has been seen. A GO batch separator on the following line is also treated as a terminator to
-     * guard against malformed input.
+     * BEGIN has been seen. A GO batch separator on the following line always terminates the unit as well,
+     * whatever the depth count believes - it is the backstop for the cases where the count is wrong, and
+     * for balanced input it costs nothing because the END check returns first.
      */
     private int findEndByBeginEndDepth(List<String> lines, int signatureEndIndex) {
         // Wrapping a body in BEGIN/END is optional in T-SQL, and depth tracking only identifies the end of
@@ -452,10 +453,15 @@ public class TSqlHeuristicUnitsExtractor {
             // dynamic SQL sits inside a multi-line string literal, which emptyStrings cannot clean, so
             // that rule cut real procedures short and invented a unit named after the literal. T-SQL
             // requires a GO between CREATE PROCEDURE batches, so there is nothing to fall back to.
+            // Unconditional, because GO ends the batch whatever the depth count believes. Guarding it
+            // with (seenProcBegin && depth == 0) made it dead: END is the only thing that decrements
+            // depth, and the END handler above returns the moment depth reaches 0 with a BEGIN seen, so
+            // that state can never survive to be tested here. The guard therefore did nothing when the
+            // depth count was right, and suppressed the terminator precisely when it was wrong -
+            // turning any miscount into the unit swallowing every later procedure in the file. A
+            // CREATE PROCEDURE cannot legally span a GO, so ending here is never wrong for valid input.
             if (k + 1 < lines.size() && GO_BATCH.matcher(lines.get(k + 1)).matches()) {
-                if (!bodyOpensWithBegin || (seenProcBegin && depth == 0)) {
-                    return k;
-                }
+                return k;
             }
         }
         return lines.size() - 1;

--- a/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/lang/tsql/TSqlHeuristicUnitsExtractor.java
+++ b/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/lang/tsql/TSqlHeuristicUnitsExtractor.java
@@ -1,0 +1,564 @@
+/*
+ * Copyright (c) 2021 Željko Obrenović. All rights reserved.
+ */
+
+package nl.obren.sokrates.sourcecode.lang.tsql;
+
+import nl.obren.sokrates.sourcecode.SourceFile;
+import nl.obren.sokrates.sourcecode.cleaners.CleanedContent;
+import nl.obren.sokrates.sourcecode.cleaners.SourceCodeCleanerUtils;
+import nl.obren.sokrates.sourcecode.lang.LanguageAnalyzerFactory;
+import nl.obren.sokrates.sourcecode.units.UnitInfo;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class TSqlHeuristicUnitsExtractor {
+
+    // Keywords are matched case-insensitively, and with Unicode word characters rather than ASCII ones.
+    // Without UNICODE_CHARACTER_CLASS, \w and therefore \b stop at the first non-ASCII letter: a Danish
+    // identifier such as @ANDoe (with a slashed o) ends the \bAND\b boundary early and counts as a
+    // branch, and a procedure named dbo.Opgoerelse (likewise) has its name truncated at that letter.
+    private static final int KEYWORD_FLAGS = Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CHARACTER_CLASS;
+
+    private static final Pattern UNIT_SIGNATURE = Pattern.compile(
+            "^\\s*(CREATE(?:\\s+OR\\s+ALTER)?|ALTER)\\s+(PROCEDURE|PROC|FUNCTION|TRIGGER)\\b",
+            KEYWORD_FLAGS);
+
+    private static final Pattern NAME_AFTER_KEYWORD = Pattern.compile(
+            "^\\s*(?:CREATE(?:\\s+OR\\s+ALTER)?|ALTER)\\s+(?:PROCEDURE|PROC|FUNCTION|TRIGGER)\\s+" +
+                    "((?:\\[[^\\]]+\\]|\"[^\"]+\"|#{0,2}\\w+)(?:\\s*\\.\\s*(?:\\[[^\\]]+\\]|\"[^\"]+\"|\\w+))?)",
+            KEYWORD_FLAGS);
+
+    // A line holding nothing but the DDL keyword, with the object keyword on the line below. Matching is
+    // otherwise line based, and this is the one split that stops a signature being recognised at all -
+    // the patterns above already join across it, since \s+ matches a newline.
+    private static final Pattern DANGLING_DDL_KEYWORD = Pattern.compile(
+            "^\\s*(?:CREATE(?:\\s+OR\\s+ALTER)?|ALTER)\\s*$", KEYWORD_FLAGS);
+
+    private static final Pattern GO_BATCH = Pattern.compile("^\\s*GO(\\s+\\d+)?\\s*$", KEYWORD_FLAGS);
+
+    // Standalone BEGIN that opens a procedural block (not BEGIN TRAN/TRY/CATCH/DIALOG/CONVERSATION).
+    // DISTRIBUTED is listed because it sits between BEGIN and TRANSACTION in BEGIN DISTRIBUTED
+    // TRANSACTION; without it that form opens a depth that nothing ever closes, since a transaction is
+    // closed by COMMIT rather than by END.
+    private static final Pattern BEGIN_OPEN = Pattern.compile(
+            "\\bBEGIN\\b(?!\\s+(?:TRAN|TRANSACTION|DISTRIBUTED|TRY|CATCH|DIALOG|CONVERSATION))",
+            KEYWORD_FLAGS);
+
+    // A delimited identifier. CASE, END, WHEN, IF and the rest are reserved words, so bracketing is the
+    // only way to use them as column names - which makes [Case], [End] and [When] the realistic form
+    // rather than an exotic one. They are masked out before any keyword is counted.
+    private static final Pattern BRACKETED_IDENTIFIER = Pattern.compile("\\[[^\\]]*\\]");
+
+    // CASE opens a nested scope that must be closed by END before the outer BEGIN/END can close.
+    private static final Pattern CASE_OPEN = Pattern.compile("\\bCASE\\b", KEYWORD_FLAGS);
+
+    // Standalone END that closes a procedural block or CASE expression
+    // (not END TRY/CATCH/TRAN/TRANSACTION/DIALOG/CONVERSATION).
+    private static final Pattern END_CLOSE = Pattern.compile(
+            "\\bEND\\b(?!\\s+(?:TRAN|TRANSACTION|TRY|CATCH|DIALOG|CONVERSATION))",
+            KEYWORD_FLAGS);
+
+    private static final Pattern AS_KEYWORD = Pattern.compile("\\bAS\\b", KEYWORD_FLAGS);
+    private static final Pattern RETURNS_TABLE = Pattern.compile("\\bRETURNS\\s+TABLE\\b", KEYWORD_FLAGS);
+    private static final Pattern RETURN_OPEN = Pattern.compile("\\bRETURN\\s*\\(", KEYWORD_FLAGS);
+
+    private static final Pattern MC_IF = Pattern.compile("\\bIF\\b", KEYWORD_FLAGS);
+    private static final Pattern MC_WHILE = Pattern.compile("\\bWHILE\\b", KEYWORD_FLAGS);
+    private static final Pattern MC_CASE = Pattern.compile("\\bCASE\\b", KEYWORD_FLAGS);
+    private static final Pattern MC_WHEN = Pattern.compile("\\bWHEN\\b", KEYWORD_FLAGS);
+    private static final Pattern MC_AND = Pattern.compile("\\bAND\\b", KEYWORD_FLAGS);
+    private static final Pattern MC_OR = Pattern.compile("\\bOR\\b", KEYWORD_FLAGS);
+    private static final Pattern MC_IIF = Pattern.compile("\\bIIF\\s*\\(", KEYWORD_FLAGS);
+    private static final Pattern MC_CHOOSE = Pattern.compile("\\bCHOOSE\\s*\\(", KEYWORD_FLAGS);
+    private static final Pattern MC_BEGIN_CATCH = Pattern.compile("\\bBEGIN\\s+CATCH\\b", KEYWORD_FLAGS);
+
+    private static final List<Pattern> MC_PATTERNS = Arrays.asList(
+            MC_IF, MC_WHILE, MC_CASE, MC_WHEN, MC_AND, MC_OR, MC_IIF, MC_CHOOSE, MC_BEGIN_CATCH);
+
+    public List<UnitInfo> extractUnits(SourceFile sourceFile) {
+        List<UnitInfo> units = new ArrayList<>();
+
+        CleanedContent cleaned = getCleanContent(sourceFile);
+        List<String> normalLines = sourceFile.getLines();
+        List<String> cleanedLines = SourceCodeCleanerUtils.splitInLines(cleaned.getCleanedContent());
+        List<Integer> lineMap = cleaned.getFileLineIndexes();
+
+        int i = 0;
+        while (i < cleanedLines.size()) {
+            String signatureHead = signatureHead(cleanedLines, i);
+            if (!UNIT_SIGNATURE.matcher(signatureHead).find()) {
+                i++;
+                continue;
+            }
+
+            String name = extractName(signatureHead);
+
+            int paramsEndIndex = findSignatureEnd(cleanedLines, i);
+            String signatureBody = joinLines(cleanedLines, i, paramsEndIndex);
+            int numberOfParameters = countParameters(signatureBody);
+
+            boolean isInlineTvf = isInlineTableValuedFunction(signatureBody);
+
+            int endIndex;
+            if (isInlineTvf) {
+                endIndex = findEndOfInlineTvf(cleanedLines, paramsEndIndex);
+            } else {
+                endIndex = findEndByBeginEndDepth(cleanedLines, paramsEndIndex);
+            }
+
+            if (endIndex < i) {
+                endIndex = i;
+            }
+
+            int startLine = fileLine(lineMap, i) + 1;
+            int endLine = fileLine(lineMap, endIndex) + 1;
+
+            StringBuilder body = new StringBuilder();
+            for (int j = i; j <= endIndex; j++) {
+                body.append(cleanedLines.get(j)).append("\n");
+            }
+
+            UnitInfo unit = new UnitInfo();
+            unit.setSourceFile(sourceFile);
+            unit.setShortName(name.isEmpty() ? "AnonymousBlock" : name);
+            unit.setStartLine(startLine);
+            unit.setEndLine(endLine);
+            unit.setLinesOfCode(endIndex - i + 1);
+            unit.setCleanedBody(body.toString());
+            unit.setBody(rawBody(normalLines, startLine, endLine));
+            unit.setMcCabeIndex(computeMcCabeIndex(withoutDdlKeyword(body.toString())));
+            unit.setNumberOfParameters(numberOfParameters);
+            units.add(unit);
+
+            i = endIndex + 1;
+        }
+
+        return units;
+    }
+
+    private CleanedContent getCleanContent(SourceFile sourceFile) {
+        CleanedContent normallyCleanedContent = LanguageAnalyzerFactory.getInstance()
+                .getLanguageAnalyzer(sourceFile).cleanForLinesOfCodeCalculations(sourceFile);
+        normallyCleanedContent.setCleanedContent(extraCleanContent(normallyCleanedContent.getCleanedContent()));
+        return normallyCleanedContent;
+    }
+
+    protected String extraCleanContent(String content) {
+        String cleanedContent = emptyStrings(content);
+        cleanedContent = SourceCodeCleanerUtils.normalizeLineEnds(cleanedContent);
+        return cleanedContent;
+    }
+
+    private String emptyStrings(String cleanedContent) {
+        return cleanedContent.replaceAll("'.*?'", "''");
+    }
+
+    private int fileLine(List<Integer> lineMap, int cleanedIndex) {
+        if (cleanedIndex < 0) return 0;
+        if (cleanedIndex >= lineMap.size()) {
+            return lineMap.isEmpty() ? 0 : lineMap.get(lineMap.size() - 1);
+        }
+        return lineMap.get(cleanedIndex);
+    }
+
+    private String rawBody(List<String> normalLines, int startLine1Based, int endLine1Based) {
+        StringBuilder sb = new StringBuilder();
+        int from = Math.max(0, startLine1Based - 1);
+        int to = Math.min(normalLines.size(), endLine1Based);
+        for (int k = from; k < to; k++) {
+            sb.append(normalLines.get(k)).append("\n");
+        }
+        return sb.toString();
+    }
+
+    /**
+     * The text a unit signature is recognised from: the line itself, or that line plus the next one when
+     * it holds nothing but the DDL keyword.
+     */
+    private String signatureHead(List<String> lines, int index) {
+        String line = lines.get(index);
+        if (index + 1 < lines.size() && DANGLING_DDL_KEYWORD.matcher(line).matches()) {
+            return line + "\n" + lines.get(index + 1);
+        }
+        return line;
+    }
+
+    String extractName(String signatureLine) {
+        Matcher m = NAME_AFTER_KEYWORD.matcher(signatureLine);
+        if (m.find()) {
+            return normaliseSpaces(m.group(1));
+        }
+        return "";
+    }
+
+    private String normaliseSpaces(String s) {
+        return s.replaceAll("\\s*\\.\\s*", ".").trim();
+    }
+
+    /**
+     * Find the cleaned-line index at which the unit signature ends (the line containing the top-level AS,
+     * or the line containing RETURN(...) for inline TVFs). The returned index is inclusive.
+     */
+    private int findSignatureEnd(List<String> lines, int startIndex) {
+        int parenDepth = 0;
+        for (int k = startIndex; k < lines.size(); k++) {
+            String line = lines.get(k);
+            for (int c = 0; c < line.length(); c++) {
+                char ch = line.charAt(c);
+                if (ch == '(') parenDepth++;
+                else if (ch == ')') parenDepth = Math.max(0, parenDepth - 1);
+            }
+            if (parenDepth == 0) {
+                Matcher as = AS_KEYWORD.matcher(line);
+                while (as.find()) {
+                    return k;
+                }
+                // Some triggers use FOR/AFTER/INSTEAD OF without AS — a BEGIN on its own line ends the sig too.
+                if (BEGIN_OPEN.matcher(line).find()) {
+                    return k;
+                }
+            }
+        }
+        return lines.size() - 1;
+    }
+
+    private String joinLines(List<String> lines, int from, int to) {
+        StringBuilder sb = new StringBuilder();
+        int end = Math.min(lines.size() - 1, to);
+        for (int k = from; k <= end; k++) {
+            sb.append(lines.get(k)).append("\n");
+        }
+        return sb.toString();
+    }
+
+    int countParameters(String signature) {
+        String afterName = stripUntilNameEnd(signature);
+        String beforeAs = stripAtAs(afterName);
+
+        // The parameter-list parentheses (if present) are the very first non-whitespace token after the
+        // unit name. Any parenthesised construct later in the signature (e.g. VARCHAR(10) in a bareword
+        // parameter list) is part of a parameter declaration, not a wrapper around it.
+        int firstNonWs = indexOfFirstNonWhitespace(beforeAs);
+        String paramBlock;
+        if (firstNonWs >= 0 && beforeAs.charAt(firstNonWs) == '(') {
+            int matchingClose = findMatchingCloseParen(beforeAs, firstNonWs);
+            if (matchingClose < 0) {
+                paramBlock = beforeAs.substring(firstNonWs + 1);
+            } else {
+                paramBlock = beforeAs.substring(firstNonWs + 1, matchingClose);
+            }
+        } else {
+            paramBlock = beforeAs;
+        }
+
+        return countAtParameters(paramBlock);
+    }
+
+    private int indexOfFirstNonWhitespace(String s) {
+        for (int i = 0; i < s.length(); i++) {
+            if (!Character.isWhitespace(s.charAt(i))) return i;
+        }
+        return -1;
+    }
+
+    private String stripUntilNameEnd(String signature) {
+        Matcher m = NAME_AFTER_KEYWORD.matcher(signature);
+        if (m.find()) {
+            return signature.substring(m.end());
+        }
+        return signature;
+    }
+
+    private String stripAtAs(String text) {
+        int parenDepth = 0;
+        for (int i = 0; i < text.length(); i++) {
+            char ch = text.charAt(i);
+            if (ch == '(') parenDepth++;
+            else if (ch == ')') parenDepth = Math.max(0, parenDepth - 1);
+            else if (parenDepth == 0) {
+                if (i + 2 <= text.length() && isWordBoundaryBefore(text, i) && matchesIgnoreCase(text, i, "AS")
+                        && isWordBoundaryAfter(text, i + 2)) {
+                    return text.substring(0, i);
+                }
+            }
+        }
+        return text;
+    }
+
+    private boolean isWordBoundaryBefore(String s, int pos) {
+        if (pos == 0) return true;
+        char prev = s.charAt(pos - 1);
+        return !Character.isLetterOrDigit(prev) && prev != '_';
+    }
+
+    private boolean isWordBoundaryAfter(String s, int pos) {
+        if (pos >= s.length()) return true;
+        char next = s.charAt(pos);
+        return !Character.isLetterOrDigit(next) && next != '_';
+    }
+
+    private boolean matchesIgnoreCase(String s, int pos, String needle) {
+        if (pos + needle.length() > s.length()) return false;
+        return s.regionMatches(true, pos, needle, 0, needle.length());
+    }
+
+    private int findMatchingCloseParen(String s, int openIndex) {
+        int depth = 0;
+        for (int i = openIndex; i < s.length(); i++) {
+            char ch = s.charAt(i);
+            if (ch == '(') depth++;
+            else if (ch == ')') {
+                depth--;
+                if (depth == 0) return i;
+            }
+        }
+        return -1;
+    }
+
+    private int countAtParameters(String paramBlock) {
+        int count = 0;
+        int parenDepth = 0;
+        boolean sawAt = false;
+        for (int i = 0; i < paramBlock.length(); i++) {
+            char ch = paramBlock.charAt(i);
+            if (ch == '(') parenDepth++;
+            else if (ch == ')') parenDepth = Math.max(0, parenDepth - 1);
+            else if (parenDepth == 0 && ch == '@') {
+                if (!sawAt) {
+                    count++;
+                    sawAt = true;
+                }
+            } else if (parenDepth == 0 && ch == ',') {
+                sawAt = false;
+            }
+        }
+        return count;
+    }
+
+    private boolean isInlineTableValuedFunction(String signatureBody) {
+        if (!RETURNS_TABLE.matcher(signatureBody).find()) return false;
+        return !BEGIN_OPEN.matcher(signatureBody).find();
+    }
+
+    private int findEndOfInlineTvf(List<String> lines, int signatureEndIndex) {
+        // Start after the signature line; look for RETURN ( ... ) terminated by optional ; then GO or next CREATE.
+        int parenDepth = 0;
+        boolean returnSeen = false;
+        boolean returnClosed = false;
+        for (int k = signatureEndIndex; k < lines.size(); k++) {
+            String line = lines.get(k);
+
+            if (!returnSeen) {
+                Matcher r = RETURN_OPEN.matcher(line);
+                if (r.find()) {
+                    returnSeen = true;
+                    // start counting paren depth from the opening paren
+                    int startPos = r.end() - 1; // position of '('
+                    parenDepth = countParens(line, startPos, line.length());
+                    if (parenDepth == 0) {
+                        returnClosed = true;
+                    }
+                    if (returnClosed && endsStatementOrBatch(line, k, lines)) {
+                        return k;
+                    }
+                    continue;
+                }
+            } else {
+                parenDepth += countParens(line, 0, line.length());
+                if (parenDepth == 0) {
+                    returnClosed = true;
+                }
+                if (returnClosed && endsStatementOrBatch(line, k, lines)) {
+                    return k;
+                }
+            }
+
+            if (k + 1 < lines.size() && GO_BATCH.matcher(lines.get(k + 1)).matches()) {
+                return k;
+            }
+        }
+        return lines.size() - 1;
+    }
+
+    private int countParens(String line, int from, int to) {
+        int depth = 0;
+        int end = Math.min(line.length(), to);
+        for (int i = from; i < end; i++) {
+            char ch = line.charAt(i);
+            if (ch == '(') depth++;
+            else if (ch == ')') depth--;
+        }
+        return depth;
+    }
+
+    private boolean endsStatementOrBatch(String line, int lineIndex, List<String> lines) {
+        if (line.trim().endsWith(";")) return true;
+        if (lineIndex + 1 < lines.size() && GO_BATCH.matcher(lines.get(lineIndex + 1)).matches()) return true;
+        return lineIndex == lines.size() - 1;
+    }
+
+    /**
+     * Walks BEGIN / CASE / END tokens in order of occurrence and tracks depth. BEGIN and CASE both open a
+     * scope (+1); END closes either. The unit ends when depth returns to 0 at an END after at least one
+     * BEGIN has been seen. A GO batch separator on the following line is also treated as a terminator to
+     * guard against malformed input.
+     */
+    private int findEndByBeginEndDepth(List<String> lines, int signatureEndIndex) {
+        // Wrapping a body in BEGIN/END is optional in T-SQL, and depth tracking only identifies the end of
+        // the unit when the body actually opens with one. Where it does not, the first BEGIN belongs to an
+        // inner IF or WHILE, and closing the unit when that returns to depth 0 would end it at the first
+        // inner block - dropping everything after it from the unit's size and complexity.
+        boolean bodyOpensWithBegin = bodyOpensWithBegin(lines, signatureEndIndex);
+
+        int depth = 0;
+        boolean seenProcBegin = false;
+        for (int k = signatureEndIndex; k < lines.size(); k++) {
+            if (bodyOpensWithBegin) {
+                for (Token t : scanBeginCaseEnd(lines.get(k))) {
+                    if (t.kind == TokenKind.BEGIN || t.kind == TokenKind.CASE) {
+                        depth++;
+                        if (t.kind == TokenKind.BEGIN) {
+                            seenProcBegin = true;
+                        }
+                    } else { // END
+                        depth--;
+                        if (seenProcBegin && depth == 0) {
+                            return k;
+                        }
+                        if (depth < 0) {
+                            return k;
+                        }
+                    }
+                }
+            }
+
+            // Only the batch separator ends a body that did not open with its own BEGIN. Ending it at the
+            // next line that looks like a definition was tried and withdrawn: a CREATE PROCEDURE built in
+            // dynamic SQL sits inside a multi-line string literal, which emptyStrings cannot clean, so
+            // that rule cut real procedures short and invented a unit named after the literal. T-SQL
+            // requires a GO between CREATE PROCEDURE batches, so there is nothing to fall back to.
+            if (k + 1 < lines.size() && GO_BATCH.matcher(lines.get(k + 1)).matches()) {
+                if (!bodyOpensWithBegin || (seenProcBegin && depth == 0)) {
+                    return k;
+                }
+            }
+        }
+        return lines.size() - 1;
+    }
+
+    /**
+     * Whether the unit's body opens with its own BEGIN, as opposed to starting with a statement.
+     *
+     * <p>The BEGIN may sit on the signature line itself ({@code ... AS BEGIN}) or be the first thing on a
+     * following line. Anything else first - a SELECT, an IF, a DECLARE - means the body is a bare
+     * statement sequence, which only the batch separator or the end of the file terminates.
+     */
+    private boolean bodyOpensWithBegin(List<String> lines, int signatureEndIndex) {
+        String signatureLine = maskBracketedIdentifiers(lines.get(signatureEndIndex));
+        Matcher as = AS_KEYWORD.matcher(signatureLine);
+        if (as.find()) {
+            String afterAs = signatureLine.substring(as.end());
+            if (BEGIN_OPEN.matcher(afterAs).find()) {
+                return true;
+            }
+            if (!afterAs.trim().isEmpty()) {
+                return false;
+            }
+        } else if (BEGIN_OPEN.matcher(signatureLine).find()) {
+            // The trigger form, where a BEGIN rather than an AS ended the signature.
+            return true;
+        }
+
+        for (int k = signatureEndIndex + 1; k < lines.size(); k++) {
+            String line = maskBracketedIdentifiers(lines.get(k)).trim();
+            if (line.isEmpty()) {
+                continue;
+            }
+            Matcher begin = BEGIN_OPEN.matcher(line);
+            return begin.find() && begin.start() == 0;
+        }
+        return false;
+    }
+
+    private enum TokenKind { BEGIN, CASE, END }
+
+    private static class Token {
+        final int pos;
+        final TokenKind kind;
+
+        Token(int pos, TokenKind kind) {
+            this.pos = pos;
+            this.kind = kind;
+        }
+    }
+
+    /**
+     * Blanks out delimited identifiers, keeping the line the same length so token positions still line up.
+     */
+    private String maskBracketedIdentifiers(String line) {
+        Matcher m = BRACKETED_IDENTIFIER.matcher(line);
+        if (!m.find()) {
+            return line;
+        }
+        StringBuilder masked = new StringBuilder(line);
+        m.reset();
+        while (m.find()) {
+            for (int i = m.start(); i < m.end(); i++) {
+                masked.setCharAt(i, ' ');
+            }
+        }
+        return masked.toString();
+    }
+
+    private List<Token> scanBeginCaseEnd(String rawLine) {
+        String line = maskBracketedIdentifiers(rawLine);
+        List<Token> tokens = new ArrayList<>();
+        Matcher beginMatcher = BEGIN_OPEN.matcher(line);
+        while (beginMatcher.find()) {
+            tokens.add(new Token(beginMatcher.start(), TokenKind.BEGIN));
+        }
+        Matcher caseMatcher = CASE_OPEN.matcher(line);
+        while (caseMatcher.find()) {
+            tokens.add(new Token(caseMatcher.start(), TokenKind.CASE));
+        }
+        Matcher endMatcher = END_CLOSE.matcher(line);
+        while (endMatcher.find()) {
+            tokens.add(new Token(endMatcher.start(), TokenKind.END));
+        }
+        tokens.sort((a, b) -> Integer.compare(a.pos, b.pos));
+        return tokens;
+    }
+
+    /**
+     * Removes the leading CREATE / CREATE OR ALTER / ALTER keyword before complexity is counted.
+     *
+     * <p>The OR in CREATE OR ALTER is part of the DDL statement, not a boolean operator in the code, so
+     * counting it scores a procedure one higher than the byte-identical procedure declared with a plain
+     * CREATE. Only the keyword is removed, not the whole signature line: an inline table-valued function
+     * carries its entire body on that line, and its decisions have to keep counting.
+     */
+    private String withoutDdlKeyword(String body) {
+        Matcher m = UNIT_SIGNATURE.matcher(body);
+        if (m.find()) {
+            return body.substring(0, m.start()) + body.substring(m.end());
+        }
+        return body;
+    }
+
+    int computeMcCabeIndex(String cleanedBody) {
+        String body = maskBracketedIdentifiers(cleanedBody);
+        int mc = 1;
+        for (Pattern p : MC_PATTERNS) {
+            Matcher m = p.matcher(body);
+            while (m.find()) {
+                mc++;
+            }
+        }
+        return mc;
+    }
+}

--- a/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/lang/tsql/TSqlAnalyzerTest.java
+++ b/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/lang/tsql/TSqlAnalyzerTest.java
@@ -1,0 +1,318 @@
+/*
+ * Copyright (c) 2021 Željko Obrenović. All rights reserved.
+ */
+
+package nl.obren.sokrates.sourcecode.lang.tsql;
+
+import nl.obren.sokrates.sourcecode.SourceFile;
+import nl.obren.sokrates.sourcecode.cleaners.CleanedContent;
+import nl.obren.sokrates.sourcecode.units.UnitInfo;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class TSqlAnalyzerTest {
+
+    private TSqlAnalyzer analyzer;
+
+    @Before
+    public void init() {
+        analyzer = new TSqlAnalyzer();
+    }
+
+    private SourceFile srcFile(String content) {
+        return srcFile("test.tsql", content);
+    }
+
+    private SourceFile srcFile(String name, String content) {
+        return new SourceFile(new File(name), content);
+    }
+
+    @Test
+    public void cleanForLinesOfCodeCalculations_removesCommentsAndEmptyLines() {
+        CleanedContent cleaned = analyzer.cleanForLinesOfCodeCalculations(srcFile(TSqlExamples.CONTENT_LOC));
+        assertEquals(TSqlExamples.CONTENT_LOC_CLEANED, cleaned.getCleanedContent());
+    }
+
+    @Test
+    public void cleanForDuplicationCalculations_trimsWhitespaceAndEmptiesStrings() {
+        CleanedContent cleaned = analyzer.cleanForDuplicationCalculations(srcFile(TSqlExamples.CONTENT_DUP));
+        assertEquals(TSqlExamples.CONTENT_DUP_CLEANED, cleaned.getCleanedContent());
+    }
+
+    @Test
+    public void extractUnits_simpleProcedureWithIfElse() {
+        List<UnitInfo> units = analyzer.extractUnits(srcFile(TSqlExamples.SIMPLE_PROCEDURE));
+        assertEquals(1, units.size());
+        UnitInfo unit = units.get(0);
+        assertEquals("dbo.foo", unit.getShortName());
+        assertEquals(1, unit.getNumberOfParameters());
+        // McCabe: base 1 + IF(1). ELSE is not a decision point on its own.
+        assertEquals(2, unit.getMcCabeIndex());
+        assertEquals(8, unit.getLinesOfCode());
+        assertEquals(1, unit.getStartLine());
+        assertEquals(8, unit.getEndLine());
+    }
+
+    @Test
+    public void extractUnits_whileAndCase() {
+        List<UnitInfo> units = analyzer.extractUnits(srcFile(TSqlExamples.WHILE_AND_CASE_PROCEDURE));
+        assertEquals(1, units.size());
+        UnitInfo unit = units.get(0);
+        assertEquals("dbo.bar", unit.getShortName());
+        assertEquals(0, unit.getNumberOfParameters());
+        // McCabe: 1 + WHILE(1) + CASE(1) + WHEN(2) = 5.
+        assertEquals(5, unit.getMcCabeIndex());
+        assertEquals(10, unit.getLinesOfCode());
+    }
+
+    @Test
+    public void extractUnits_tryCatchDoesNotTerminateEarly() {
+        List<UnitInfo> units = analyzer.extractUnits(srcFile(TSqlExamples.TRY_CATCH_PROCEDURE));
+        assertEquals(1, units.size());
+        UnitInfo unit = units.get(0);
+        assertEquals("dbo.baz", unit.getShortName());
+        // Without the TRY/CATCH exclusion the unit would close at 'END TRY' (line 6) instead of the
+        // outer 'END' (line 10).
+        assertEquals(10, unit.getLinesOfCode());
+        // McCabe: 1 + BEGIN CATCH(1) = 2.
+        assertEquals(2, unit.getMcCabeIndex());
+    }
+
+    @Test
+    public void extractUnits_parenthesisedParameterList() {
+        List<UnitInfo> units = analyzer.extractUnits(srcFile(TSqlExamples.PAREN_PARAMS_PROCEDURE));
+        assertEquals(1, units.size());
+        assertEquals(2, units.get(0).getNumberOfParameters());
+        assertEquals("dbo.p1", units.get(0).getShortName());
+    }
+
+    @Test
+    public void extractUnits_barewordParameterList() {
+        List<UnitInfo> units = analyzer.extractUnits(srcFile(TSqlExamples.BAREWORD_PARAMS_PROCEDURE));
+        assertEquals(1, units.size());
+        assertEquals(2, units.get(0).getNumberOfParameters());
+        assertEquals("dbo.p2", units.get(0).getShortName());
+    }
+
+    @Test
+    public void extractUnits_inlineTableValuedFunction() {
+        List<UnitInfo> units = analyzer.extractUnits(srcFile(TSqlExamples.INLINE_TVF));
+        assertEquals(1, units.size());
+        UnitInfo unit = units.get(0);
+        assertEquals("dbo.f1", unit.getShortName());
+        assertEquals(1, unit.getNumberOfParameters());
+        assertEquals(1, unit.getMcCabeIndex());
+        // Whole definition fits on one line.
+        assertEquals(1, unit.getLinesOfCode());
+        assertEquals(1, unit.getStartLine());
+        assertEquals(1, unit.getEndLine());
+    }
+
+    @Test
+    public void extractUnits_twoProceduresSeparatedByGo() {
+        List<UnitInfo> units = analyzer.extractUnits(srcFile(TSqlExamples.TWO_PROCS_WITH_GO));
+        assertEquals(2, units.size());
+        assertEquals("dbo.p1", units.get(0).getShortName());
+        assertEquals("dbo.p2", units.get(1).getShortName());
+        assertEquals(5, units.get(0).getLinesOfCode());
+        assertEquals(5, units.get(1).getLinesOfCode());
+        // Second unit starts after the GO and any intermediate blank lines.
+        assertEquals(1, units.get(0).getStartLine());
+        assertEquals(5, units.get(0).getEndLine());
+        assertEquals(7, units.get(1).getStartLine());
+        assertEquals(11, units.get(1).getEndLine());
+    }
+
+    @Test
+    public void extractUnits_createOrAlter() {
+        List<UnitInfo> units = analyzer.extractUnits(srcFile(TSqlExamples.CREATE_OR_ALTER));
+        assertEquals(1, units.size());
+        assertEquals("dbo.p3", units.get(0).getShortName());
+        assertEquals(1, units.get(0).getNumberOfParameters());
+    }
+
+    @Test
+    public void extractUnits_theDdlKeywordDoesNotAffectComplexity() {
+        // The OR in "CREATE OR ALTER" is part of the DDL statement, not a boolean operator in the code.
+        // Counting it scored this procedure 2 against 1 for the byte-identical plain-CREATE form, so the
+        // two are asserted against each other rather than against a literal.
+        UnitInfo createOrAlter = only(analyzer.extractUnits(srcFile(TSqlExamples.CREATE_OR_ALTER)));
+        UnitInfo plainCreate = only(analyzer.extractUnits(srcFile(TSqlExamples.PLAIN_CREATE_COUNTERPART)));
+
+        assertEquals(1, plainCreate.getMcCabeIndex());
+        assertEquals(plainCreate.getMcCabeIndex(), createOrAlter.getMcCabeIndex());
+    }
+
+    @Test
+    public void extractUnits_procAbbreviationAndBareAlter() {
+        UnitInfo proc = only(analyzer.extractUnits(srcFile(TSqlExamples.PROC_ABBREVIATION)));
+        assertEquals("dbo.abbr", proc.getShortName());
+        assertEquals(1, proc.getNumberOfParameters());
+        assertEquals(5, proc.getEndLine());
+
+        UnitInfo altered = only(analyzer.extractUnits(srcFile(TSqlExamples.BARE_ALTER)));
+        assertEquals("dbo.alt", altered.getShortName());
+        assertEquals(1, altered.getNumberOfParameters());
+        assertEquals(5, altered.getEndLine());
+    }
+
+    @Test
+    public void extractUnits_trigger() {
+        // The signature runs name -> ON -> AFTER INSERT -> AS, so the body must not be taken to start
+        // before the AS.
+        UnitInfo unit = only(analyzer.extractUnits(srcFile(TSqlExamples.TRIGGER)));
+        assertEquals("dbo.trg", unit.getShortName());
+        assertEquals(0, unit.getNumberOfParameters());
+        assertEquals(1, unit.getStartLine());
+        assertEquals(5, unit.getEndLine());
+    }
+
+    @Test
+    public void extractUnits_scalarFunctionTakesTheBeginEndRoute() {
+        UnitInfo unit = only(analyzer.extractUnits(srcFile(TSqlExamples.SCALAR_FUNCTION)));
+        assertEquals("dbo.sc", unit.getShortName());
+        assertEquals(1, unit.getNumberOfParameters());
+        assertEquals(5, unit.getEndLine());
+    }
+
+    @Test
+    public void extractUnits_multiStatementTvfIsNotTreatedAsInline() {
+        // "RETURNS @t TABLE (...)" contains the word TABLE but has a BEGIN/END body, so it must take the
+        // BEGIN/END route; the inline route would end it at the first statement terminator.
+        UnitInfo unit = only(analyzer.extractUnits(srcFile(TSqlExamples.MULTI_STATEMENT_TVF)));
+        assertEquals("dbo.mstvf", unit.getShortName());
+        assertEquals(1, unit.getNumberOfParameters());
+        assertEquals(1, unit.getStartLine());
+        assertEquals(6, unit.getEndLine());
+    }
+
+    @Test
+    public void extractUnits_bodyWithNoBeginEndsAtTheBatchSeparator() {
+        List<UnitInfo> units = analyzer.extractUnits(srcFile(TSqlExamples.NO_BEGIN_SINGLE_STATEMENT));
+        assertEquals(2, units.size());
+        assertEquals("dbo.s", units.get(0).getShortName());
+        // Ends at the statement before GO, not swallowing the procedure that follows it.
+        assertEquals(1, units.get(0).getStartLine());
+        assertEquals(3, units.get(0).getEndLine());
+        assertEquals("dbo.t", units.get(1).getShortName());
+        assertEquals(5, units.get(1).getStartLine());
+        assertEquals(9, units.get(1).getEndLine());
+    }
+
+    @Test
+    public void extractUnits_iifAndChooseAreBranches() {
+        // Both are branch constructs written as function calls. IIF must also not be counted twice by the
+        // plain IF pattern - "IIF" has no word boundary before its trailing "IF".
+        assertEquals(3, only(analyzer.extractUnits(srcFile(TSqlExamples.IIF_AND_CHOOSE))).getMcCabeIndex());
+    }
+
+    @Test
+    public void extractUnits_keywordsInsideStringLiteralsAreNotCounted() {
+        assertEquals(1, only(analyzer.extractUnits(
+                srcFile(TSqlExamples.KEYWORDS_IN_STRING_LITERAL))).getMcCabeIndex());
+    }
+
+    @Test
+    public void extractUnits_commentedOutDefinitionIsIgnored() {
+        UnitInfo unit = only(analyzer.extractUnits(srcFile(TSqlExamples.COMMENTED_OUT_DEFINITION)));
+        assertEquals("dbo.real", unit.getShortName());
+        // Line 1 is the commented-out definition, so a correct extractor cannot start the unit there.
+        assertEquals(2, unit.getStartLine());
+        assertEquals(6, unit.getEndLine());
+    }
+
+    @Test
+    public void extractUnits_bodyWithNoOuterBeginRunsPastItsInnerBlocks() {
+        // The first BEGIN here belongs to the IF on line 3, not to the procedure. Treating it as the
+        // procedure's own closed the unit at line 6 and dropped the second IF from size and complexity.
+        UnitInfo unit = only(analyzer.extractUnits(srcFile(TSqlExamples.NO_OUTER_BEGIN_WITH_INNER_BLOCKS)));
+        assertEquals("dbo.p1", unit.getShortName());
+        assertEquals(1, unit.getStartLine());
+        assertEquals(10, unit.getEndLine());
+        // Base 1 + IF + IF. Both branches are inside the unit, so both are counted.
+        assertEquals(3, unit.getMcCabeIndex());
+    }
+
+    @Test
+    public void extractUnits_distributedTransactionDoesNotOpenABlock() {
+        // A transaction is closed by COMMIT, not END. Counting BEGIN DISTRIBUTED TRANSACTION as an open
+        // block left a depth that never returned to zero, so dbo.p1 swallowed dbo.p2 and the file
+        // reported one unit instead of two.
+        List<UnitInfo> units = analyzer.extractUnits(srcFile(TSqlExamples.DISTRIBUTED_TRANSACTION));
+        assertEquals(2, units.size());
+        assertEquals("dbo.p1", units.get(0).getShortName());
+        assertEquals(7, units.get(0).getEndLine());
+        assertEquals("dbo.p2", units.get(1).getShortName());
+        assertEquals(9, units.get(1).getStartLine());
+        assertEquals(13, units.get(1).getEndLine());
+    }
+
+    @Test
+    public void extractUnits_bracketedReservedWordsAreNotKeywords() {
+        // [Case] and [End] are column names. Reading them as block delimiters both corrupted the depth -
+        // dbo.p1 ran to the end of the file - and inflated complexity.
+        List<UnitInfo> units = analyzer.extractUnits(srcFile(TSqlExamples.BRACKETED_RESERVED_WORD_COLUMNS));
+        assertEquals(2, units.size());
+        assertEquals("dbo.p1", units.get(0).getShortName());
+        assertEquals(1, units.get(0).getStartLine());
+        assertEquals(6, units.get(0).getEndLine());
+        assertEquals(1, units.get(0).getMcCabeIndex());
+        assertEquals("dbo.p2", units.get(1).getShortName());
+        assertEquals(8, units.get(1).getStartLine());
+        assertEquals(12, units.get(1).getEndLine());
+    }
+
+    @Test
+    public void extractUnits_ddlKeywordOnItsOwnLine() {
+        // "CREATE" alone, with "procedure ..." on the next line. The unit still starts at the CREATE.
+        UnitInfo unit = only(analyzer.extractUnits(srcFile(TSqlExamples.SPLIT_DDL_KEYWORD)));
+        assertEquals("[dbo].[split]", unit.getShortName());
+        assertEquals(1, unit.getNumberOfParameters());
+        assertEquals(1, unit.getStartLine());
+        assertEquals(5, unit.getEndLine());
+        assertEquals(1, unit.getMcCabeIndex());
+    }
+
+    @Test
+    public void extractUnits_temporaryProcedureKeepsItsName() {
+        UnitInfo unit = only(analyzer.extractUnits(srcFile(TSqlExamples.TEMPORARY_PROCEDURE)));
+        assertEquals("#tempProc", unit.getShortName());
+        assertEquals(1, unit.getNumberOfParameters());
+    }
+
+    @Test
+    public void extractUnits_nonAsciiIdentifiers() {
+        // Java's \w is ASCII only unless told otherwise, and \b is defined in terms of it. Without the
+        // Unicode flag the name truncated at the first non-ASCII letter, and an identifier such as @ANDø
+        // ended the \bAND\b boundary early and counted as a branch.
+        UnitInfo unit = only(analyzer.extractUnits(srcFile(TSqlExamples.NON_ASCII_IDENTIFIERS)));
+        assertEquals("dbo.Opgørelse", unit.getShortName());
+        assertEquals(1, unit.getMcCabeIndex());
+    }
+
+    private UnitInfo only(List<UnitInfo> units) {
+        assertEquals(1, units.size());
+        return units.get(0);
+    }
+
+    @Test
+    public void extractUnits_bracketedName() {
+        List<UnitInfo> units = analyzer.extractUnits(srcFile(TSqlExamples.BRACKETED_NAME));
+        assertEquals(1, units.size());
+        assertEquals("[dbo].[weird name]", units.get(0).getShortName());
+    }
+
+    @Test
+    public void computeMcCabeIndex_directWordBoundaryBehaviour() {
+        TSqlHeuristicUnitsExtractor extractor = new TSqlHeuristicUnitsExtractor();
+        // identifiers that merely *contain* the keyword substring must NOT count (word boundary).
+        assertEquals(1, extractor.computeMcCabeIndex("SET @ANDY = 1; SET @IFACE = 2; SET @ORDER = 3;"));
+        // Each genuine keyword contributes +1. Base 1 + IF + AND + OR = 4.
+        assertEquals(4, extractor.computeMcCabeIndex("IF @x = 1 AND @y = 2 OR @z = 3 SELECT 1"));
+    }
+}

--- a/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/lang/tsql/TSqlAnalyzerTest.java
+++ b/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/lang/tsql/TSqlAnalyzerTest.java
@@ -16,6 +16,7 @@ import java.io.File;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class TSqlAnalyzerTest {
 
@@ -397,5 +398,67 @@ public class TSqlAnalyzerTest {
                 .getLanguageAnalyzer(new SourceFile(new File("db/procedures/Example.tsql")));
 
         assertEquals(TSqlAnalyzer.class, forTSql.getClass());
+    }
+
+    /**
+     * A backslash is an ordinary character in a T-SQL literal, so a path ending in one must not read as
+     * an escaped quote. When it did, the cleaner ran to the next quote in the file - or off the end of
+     * it - and everything past that point vanished from both unit extraction and the line count, with
+     * nothing in the report to say so.
+     */
+    @Test
+    public void extractUnits_literalEndingInABackslashDoesNotSwallowTheRestOfTheFile() {
+        List<UnitInfo> units = analyzer.extractUnits(srcFile(TSqlExamples.BACKSLASH_TERMINATED_STRING));
+
+        assertEquals(2, units.size());
+        assertEquals("dbo.p1", units.get(0).getShortName());
+        assertEquals("dbo.p2", units.get(1).getShortName());
+    }
+
+    @Test
+    public void cleanForLinesOfCode_keepsTheCodeAfterALiteralEndingInABackslash() {
+        // The same defect measured on the other consumer of the cleaner: the line count. Asserting the
+        // unit count alone would leave this half untested, and it is the half that moves a headline
+        // figure.
+        CleanedContent cleaned = analyzer.cleanForLinesOfCodeCalculations(
+                srcFile(TSqlExamples.BACKSLASH_TERMINATED_STRING));
+
+        assertTrue("code after the backslash literal must survive cleaning, got:\n" + cleaned.getCleanedContent(),
+                cleaned.getCleanedContent().contains("SELECT 2"));
+    }
+
+    @Test
+    public void extractUnits_doubledQuoteIsTheEscapeAndHidesACommentMarker() {
+        // T-SQL's real escape. The '--' inside the literal must not start a comment.
+        List<UnitInfo> units = analyzer.extractUnits(srcFile(TSqlExamples.DOUBLED_QUOTE_STRING));
+
+        assertEquals(2, units.size());
+        assertEquals("dbo.p1", units.get(0).getShortName());
+        assertEquals("dbo.p2", units.get(1).getShortName());
+    }
+
+    /**
+     * The batch separator is the backstop for a depth count that has gone wrong, so it has to fire
+     * whatever the count believes. These two cases are why: one is legal T-SQL the line-by-line scan
+     * cannot read, the other is malformed input. Both used to end with the first procedure swallowing
+     * the second.
+     */
+    @Test
+    public void extractUnits_goEndsTheUnitWhenBeginTransactionIsSplitAcrossLines() {
+        List<UnitInfo> units = analyzer.extractUnits(
+                srcFile(TSqlExamples.BEGIN_TRANSACTION_SPLIT_ACROSS_LINES));
+
+        assertEquals(2, units.size());
+        assertEquals("dbo.p1", units.get(0).getShortName());
+        assertEquals("dbo.p2", units.get(1).getShortName());
+    }
+
+    @Test
+    public void extractUnits_goEndsTheUnitWhenAnEndIsMissing() {
+        List<UnitInfo> units = analyzer.extractUnits(srcFile(TSqlExamples.MISSING_END_BEFORE_GO));
+
+        assertEquals(2, units.size());
+        assertEquals("dbo.p1", units.get(0).getShortName());
+        assertEquals("dbo.p2", units.get(1).getShortName());
     }
 }

--- a/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/lang/tsql/TSqlAnalyzerTest.java
+++ b/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/lang/tsql/TSqlAnalyzerTest.java
@@ -5,6 +5,8 @@
 package nl.obren.sokrates.sourcecode.lang.tsql;
 
 import nl.obren.sokrates.sourcecode.SourceFile;
+import nl.obren.sokrates.sourcecode.lang.LanguageAnalyzer;
+import nl.obren.sokrates.sourcecode.lang.LanguageAnalyzerFactory;
 import nl.obren.sokrates.sourcecode.cleaners.CleanedContent;
 import nl.obren.sokrates.sourcecode.units.UnitInfo;
 import org.junit.Before;
@@ -378,5 +380,22 @@ public class TSqlAnalyzerTest {
         assertEquals(1, extractor.computeMcCabeIndex("SET @ANDY = 1; SET @IFACE = 2; SET @ORDER = 3;"));
         // Each genuine keyword contributes +1. Base 1 + IF + AND + OR = 4.
         assertEquals(4, extractor.computeMcCabeIndex("IF @x = 1 AND @y = 2 OR @z = 3 SELECT 1"));
+    }
+
+    /**
+     * The wiring, which nothing else checks: registering an extension in {@link LanguageAnalyzerFactory}
+     * is a line in a different file from the analyzer it points at, and getting it wrong costs nothing
+     * at compile time. A {@code .tsql} file would simply be read as generic SQL — units still extracted,
+     * no error anywhere, and the numbers quietly those of the wrong dialect.
+     *
+     * <p>Asked through {@code getLanguageAnalyzer(SourceFile)} rather than by extension, because that is
+     * the call the analysis itself makes, and it honours {@code analyzerOverrides} as well.
+     */
+    @Test
+    public void aTSqlFileIsRoutedToThisAnalyzer() {
+        LanguageAnalyzer forTSql = LanguageAnalyzerFactory.getInstance()
+                .getLanguageAnalyzer(new SourceFile(new File("db/procedures/Example.tsql")));
+
+        assertEquals(TSqlAnalyzer.class, forTSql.getClass());
     }
 }

--- a/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/lang/tsql/TSqlAnalyzerTest.java
+++ b/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/lang/tsql/TSqlAnalyzerTest.java
@@ -461,4 +461,28 @@ public class TSqlAnalyzerTest {
         assertEquals("dbo.p1", units.get(0).getShortName());
         assertEquals("dbo.p2", units.get(1).getShortName());
     }
+
+    /**
+     * Pins what treating GO as an unconditional terminator costs, rather than leaving it undiscovered.
+     *
+     * <p>GO is client-side, so a bare GO inside a multi-line literal is valid input, and the unit
+     * holding it is cut short there. This asserts the truncation <b>as accepted behaviour</b>: the
+     * first unit is understated, and - the part that makes the trade worth it - the procedure after it
+     * is still found with correct boundaries. Restoring a guard to protect this case would bring back
+     * the failure it replaced, where any depth miscount swallowed every later procedure in the file.
+     */
+    @Test
+    public void extractUnits_goInsideAMultilineLiteralTruncatesThatUnitButNotTheFile() {
+        List<UnitInfo> units = analyzer.extractUnits(srcFile(TSqlExamples.GO_INSIDE_A_MULTILINE_LITERAL));
+
+        assertEquals(2, units.size());
+        assertEquals("dbo.p1", units.get(0).getShortName());
+        // Understated: the body really runs to its END on line 8.
+        assertEquals(1, units.get(0).getStartLine());
+        assertEquals(4, units.get(0).getEndLine());
+        // The cost stops there - the next procedure is untouched.
+        assertEquals("dbo.p2", units.get(1).getShortName());
+        assertEquals(10, units.get(1).getStartLine());
+        assertEquals(14, units.get(1).getEndLine());
+    }
 }

--- a/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/lang/tsql/TSqlAnalyzerTest.java
+++ b/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/lang/tsql/TSqlAnalyzerTest.java
@@ -304,6 +304,8 @@ public class TSqlAnalyzerTest {
         assertEquals("dbo.p1", units.get(0).getShortName());
         assertEquals(5, units.get(0).getEndLine());
         assertEquals("dbo.p2", units.get(1).getShortName());
+        assertEquals(7, units.get(1).getStartLine());
+        assertEquals(11, units.get(1).getEndLine());
     }
 
     @Test
@@ -315,6 +317,8 @@ public class TSqlAnalyzerTest {
         assertEquals("dbo.p1", units.get(0).getShortName());
         assertEquals(5, units.get(0).getEndLine());
         assertEquals("dbo.p2", units.get(1).getShortName());
+        assertEquals(7, units.get(1).getStartLine());
+        assertEquals(11, units.get(1).getEndLine());
     }
 
     @Test
@@ -337,6 +341,22 @@ public class TSqlAnalyzerTest {
         assertEquals(7, units.get(0).getEndLine());
         assertEquals(1, units.get(0).getNumberOfParameters());
         assertEquals("dbo.p2", units.get(1).getShortName());
+    }
+
+    @Test
+    public void extractUnits_longDelimitedIdentifierDoesNotExhaustTheStack() {
+        // Matching a delimited identifier with a group repeated per character makes the regex engine
+        // recurse per character, which overflowed the stack on a long one - an Error, not an Exception,
+        // so nothing upstream would have caught it. Both a closed and an unclosed delimiter are checked,
+        // since a truncated export produces the second.
+        String filler = new String(new char[40000]).replace('\0', 'x');
+
+        analyzer.extractUnits(srcFile("CREATE PROCEDURE dbo.p\nAS\nBEGIN\n  SELECT [ok" + filler
+                + "] FROM t\nEND\n"));
+        analyzer.extractUnits(srcFile("CREATE PROCEDURE dbo.p\nAS\nBEGIN\n  SELECT [unterminated"
+                + filler + "\nEND\n"));
+        analyzer.extractUnits(srcFile("CREATE PROCEDURE dbo.p\nAS\nBEGIN\n  SELECT \"unterminated"
+                + filler + "\nEND\n"));
     }
 
     private UnitInfo only(List<UnitInfo> units) {

--- a/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/lang/tsql/TSqlAnalyzerTest.java
+++ b/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/lang/tsql/TSqlAnalyzerTest.java
@@ -295,6 +295,50 @@ public class TSqlAnalyzerTest {
         assertEquals(1, unit.getMcCabeIndex());
     }
 
+    @Test
+    public void extractUnits_doubleQuotedReservedWordAlias() {
+        // Masking only [...] left the other delimiter form exposed: the word inside "BEGIN" was read as
+        // an opening block, depth never returned to zero, and dbo.p2 disappeared from the file.
+        List<UnitInfo> units = analyzer.extractUnits(srcFile(TSqlExamples.QUOTED_RESERVED_WORD_ALIAS));
+        assertEquals(2, units.size());
+        assertEquals("dbo.p1", units.get(0).getShortName());
+        assertEquals(5, units.get(0).getEndLine());
+        assertEquals("dbo.p2", units.get(1).getShortName());
+    }
+
+    @Test
+    public void extractUnits_escapedClosingBracketInIdentifier() {
+        // [Value]]Begin] is one identifier naming Value]Begin. Stopping the mask at the first ] left
+        // "Begin" exposed, with the same disappearing-procedure result.
+        List<UnitInfo> units = analyzer.extractUnits(srcFile(TSqlExamples.ESCAPED_BRACKET_IN_IDENTIFIER));
+        assertEquals(2, units.size());
+        assertEquals("dbo.p1", units.get(0).getShortName());
+        assertEquals(5, units.get(0).getEndLine());
+        assertEquals("dbo.p2", units.get(1).getShortName());
+    }
+
+    @Test
+    public void extractUnits_keywordInsideTheObjectName() {
+        // The AS in [dbo].[AS] is part of the name, not the end of the signature. Reading it as the end
+        // cut the parameter list off before it was counted.
+        UnitInfo unit = only(analyzer.extractUnits(srcFile(TSqlExamples.KEYWORD_INSIDE_DELIMITED_NAME)));
+        assertEquals("[dbo].[AS]", unit.getShortName());
+        assertEquals(2, unit.getNumberOfParameters());
+    }
+
+    @Test
+    public void extractUnits_multiLineInlineTableValuedFunction() {
+        // The single-line fixture never exercises the cross-line RETURN/paren tracking, which is how
+        // inline table-valued functions are normally written.
+        List<UnitInfo> units = analyzer.extractUnits(srcFile(TSqlExamples.MULTILINE_INLINE_TVF));
+        assertEquals(2, units.size());
+        assertEquals("dbo.f1", units.get(0).getShortName());
+        assertEquals(1, units.get(0).getStartLine());
+        assertEquals(7, units.get(0).getEndLine());
+        assertEquals(1, units.get(0).getNumberOfParameters());
+        assertEquals("dbo.p2", units.get(1).getShortName());
+    }
+
     private UnitInfo only(List<UnitInfo> units) {
         assertEquals(1, units.size());
         return units.get(0);

--- a/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/lang/tsql/TSqlExamples.java
+++ b/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/lang/tsql/TSqlExamples.java
@@ -1,0 +1,285 @@
+/*
+ * Copyright (c) 2021 Željko Obrenović. All rights reserved.
+ */
+
+package nl.obren.sokrates.sourcecode.lang.tsql;
+
+public class TSqlExamples {
+
+    // Simple T-SQL with a line comment and a block comment; after cleaning both should be gone and empty
+    // lines removed. String literals are kept by the cleaner (they are emptied only for McCabe analysis).
+    public static final String CONTENT_LOC = ""
+            + "-- line comment\n"
+            + "DECLARE @x INT;\n"
+            + "/* block\n"
+            + "   comment */\n"
+            + "\n"
+            + "SET @x = 1;\n";
+
+    public static final String CONTENT_LOC_CLEANED = ""
+            + "DECLARE @x INT;\n"
+            + "SET @x = 1;";
+
+    // Duplication cleaning strips comments and trims per-line whitespace (collapses runs of spaces).
+    // String literals are kept intact; they are emptied only during McCabe analysis.
+    public static final String CONTENT_DUP = ""
+            + "-- comment\n"
+            + "  SELECT   col, @name \n"
+            + "  FROM   dbo.t\n";
+
+    public static final String CONTENT_DUP_CLEANED = ""
+            + "SELECT col, @name\n"
+            + "FROM dbo.t";
+
+    // Simple procedure with one IF/ELSE branch. McCabe = 1 + 1 (IF) = 2, params = 1.
+    public static final String SIMPLE_PROCEDURE = ""
+            + "CREATE PROCEDURE dbo.foo @a INT\n"
+            + "AS\n"
+            + "BEGIN\n"
+            + "  IF @a > 0\n"
+            + "    SELECT 1\n"
+            + "  ELSE\n"
+            + "    SELECT 0\n"
+            + "END\n";
+
+    // Procedure exercising WHILE + CASE/WHEN counting. McCabe = 1 + WHILE(1) + CASE(1) + WHEN(2) = 5.
+    public static final String WHILE_AND_CASE_PROCEDURE = ""
+            + "CREATE PROCEDURE dbo.bar\n"
+            + "AS\n"
+            + "BEGIN\n"
+            + "  DECLARE @i INT = 0\n"
+            + "  WHILE @i < 10\n"
+            + "  BEGIN\n"
+            + "    SELECT CASE WHEN @i = 0 THEN 'a' WHEN @i = 1 THEN 'b' ELSE 'c' END\n"
+            + "    SET @i = @i + 1\n"
+            + "  END\n"
+            + "END\n";
+
+    // TRY/CATCH pairs must NOT affect BEGIN/END depth (self-balancing). McCabe = 1 + BEGIN_CATCH(1) = 2.
+    public static final String TRY_CATCH_PROCEDURE = ""
+            + "CREATE PROCEDURE dbo.baz\n"
+            + "AS\n"
+            + "BEGIN\n"
+            + "  BEGIN TRY\n"
+            + "    SELECT 1\n"
+            + "  END TRY\n"
+            + "  BEGIN CATCH\n"
+            + "    SELECT 2\n"
+            + "  END CATCH\n"
+            + "END\n";
+
+    // Parenthesised parameter list: (@a INT, @b VARCHAR(10)).
+    public static final String PAREN_PARAMS_PROCEDURE = ""
+            + "CREATE PROCEDURE dbo.p1 (@a INT, @b VARCHAR(10))\n"
+            + "AS\n"
+            + "BEGIN\n"
+            + "  SELECT 1\n"
+            + "END\n";
+
+    // Bareword parameter list: @a INT, @b VARCHAR(10) — T-SQL only.
+    public static final String BAREWORD_PARAMS_PROCEDURE = ""
+            + "CREATE PROCEDURE dbo.p2 @a INT, @b VARCHAR(10)\n"
+            + "AS\n"
+            + "BEGIN\n"
+            + "  SELECT 1\n"
+            + "END\n";
+
+    // Inline table-valued function: no BEGIN/END, terminated by statement semicolon.
+    public static final String INLINE_TVF = ""
+            + "CREATE FUNCTION dbo.f1 (@a INT) RETURNS TABLE AS RETURN (SELECT @a AS x);\n";
+
+    // Two procedures separated by a GO batch boundary — must be extracted as 2 distinct units.
+    public static final String TWO_PROCS_WITH_GO = ""
+            + "CREATE PROCEDURE dbo.p1\n"
+            + "AS\n"
+            + "BEGIN\n"
+            + "  SELECT 1\n"
+            + "END\n"
+            + "GO\n"
+            + "CREATE PROCEDURE dbo.p2\n"
+            + "AS\n"
+            + "BEGIN\n"
+            + "  SELECT 2\n"
+            + "END\n"
+            + "GO\n";
+
+    // CREATE OR ALTER introduced in SQL Server 2016+.
+    public static final String CREATE_OR_ALTER = ""
+            + "CREATE OR ALTER PROCEDURE dbo.p3 @a INT\n"
+            + "AS\n"
+            + "BEGIN\n"
+            + "  SELECT @a\n"
+            + "END\n";
+
+    // Bracket-quoted name preserves the bracketed, schema-qualified form in shortName.
+    public static final String BRACKETED_NAME = ""
+            + "CREATE PROCEDURE [dbo].[weird name]\n"
+            + "AS\n"
+            + "BEGIN\n"
+            + "  SELECT 1\n"
+            + "END\n";
+
+    // Byte-identical to CREATE_OR_ALTER apart from the DDL keyword. Pinning the pair together is what
+    // makes it visible that the OR in "CREATE OR ALTER" is not a decision point.
+    public static final String PLAIN_CREATE_COUNTERPART = ""
+            + "CREATE PROCEDURE dbo.p3 @a INT\n"
+            + "AS\n"
+            + "BEGIN\n"
+            + "  SELECT @a\n"
+            + "END\n";
+
+    // The PROC abbreviation is as common as the full keyword in hand-written T-SQL.
+    public static final String PROC_ABBREVIATION = ""
+            + "CREATE PROC dbo.abbr @a INT\n"
+            + "AS\n"
+            + "BEGIN\n"
+            + "  SELECT 1\n"
+            + "END\n";
+
+    // A bare ALTER, with no CREATE — the form a deployment script uses for an object that already exists.
+    public static final String BARE_ALTER = ""
+            + "ALTER PROCEDURE dbo.alt @a INT\n"
+            + "AS\n"
+            + "BEGIN\n"
+            + "  SELECT 1\n"
+            + "END\n";
+
+    // Trigger signature: FOR/AFTER/INSTEAD OF between the name and AS.
+    public static final String TRIGGER = ""
+            + "CREATE TRIGGER dbo.trg ON dbo.t AFTER INSERT\n"
+            + "AS\n"
+            + "BEGIN\n"
+            + "  SELECT 1\n"
+            + "END\n";
+
+    // Scalar function: RETURNS <type> rather than RETURNS TABLE, so it takes the BEGIN/END route rather
+    // than the inline table-valued one.
+    public static final String SCALAR_FUNCTION = ""
+            + "CREATE FUNCTION dbo.sc (@a INT) RETURNS INT\n"
+            + "AS\n"
+            + "BEGIN\n"
+            + "  RETURN @a\n"
+            + "END\n";
+
+    // Multi-statement table-valued function: RETURNS @t TABLE (...) — despite the word TABLE this has a
+    // BEGIN/END body and must NOT take the inline route.
+    public static final String MULTI_STATEMENT_TVF = ""
+            + "CREATE FUNCTION dbo.mstvf (@a INT) RETURNS @t TABLE (x INT)\n"
+            + "AS\n"
+            + "BEGIN\n"
+            + "  INSERT @t SELECT @a\n"
+            + "  RETURN\n"
+            + "END\n";
+
+    // A body with no BEGIN at all — a single statement, ended by the batch separator.
+    public static final String NO_BEGIN_SINGLE_STATEMENT = ""
+            + "CREATE PROCEDURE dbo.s\n"
+            + "AS\n"
+            + "  SELECT 1\n"
+            + "GO\n"
+            + "CREATE PROCEDURE dbo.t\n"
+            + "AS\n"
+            + "BEGIN\n"
+            + "  SELECT 2\n"
+            + "END\n";
+
+    // IIF and CHOOSE are branch constructs written as function calls.
+    public static final String IIF_AND_CHOOSE = ""
+            + "CREATE PROCEDURE dbo.i\n"
+            + "AS\n"
+            + "BEGIN\n"
+            + "  SELECT IIF(@x > 0, 1, 0), CHOOSE(@y, 'a', 'b')\n"
+            + "END\n";
+
+    // Keywords inside a string literal are data, not control flow.
+    public static final String KEYWORDS_IN_STRING_LITERAL = ""
+            + "CREATE PROCEDURE dbo.strlit\n"
+            + "AS\n"
+            + "BEGIN\n"
+            + "  SELECT 'IF WHILE AND OR CASE WHEN'\n"
+            + "END\n";
+
+    // A body with no BEGIN of its own, whose inner IF blocks each have one. Closing the unit when the
+    // first inner block closes would end it at line 6 and drop lines 7-10.
+    public static final String NO_OUTER_BEGIN_WITH_INNER_BLOCKS = ""
+            + "CREATE PROCEDURE dbo.p1\n"
+            + "AS\n"
+            + "IF @x = 1\n"
+            + "BEGIN\n"
+            + "  SELECT 1\n"
+            + "END\n"
+            + "IF @x = 2\n"
+            + "BEGIN\n"
+            + "  SELECT 2\n"
+            + "END\n"
+            + "GO\n";
+
+    // BEGIN DISTRIBUTED TRANSACTION is closed by COMMIT, not by END, so it must not open a depth.
+    public static final String DISTRIBUTED_TRANSACTION = ""
+            + "CREATE PROCEDURE dbo.p1\n"
+            + "AS\n"
+            + "BEGIN\n"
+            + "  BEGIN DISTRIBUTED TRANSACTION\n"
+            + "  SELECT 1\n"
+            + "  COMMIT\n"
+            + "END\n"
+            + "GO\n"
+            + "CREATE PROCEDURE dbo.p2\n"
+            + "AS\n"
+            + "BEGIN\n"
+            + "  SELECT 2\n"
+            + "END\n"
+            + "GO\n";
+
+    // CASE and END are reserved words, so bracketing is the only way to use them as column names.
+    public static final String BRACKETED_RESERVED_WORD_COLUMNS = ""
+            + "CREATE PROCEDURE dbo.p1\n"
+            + "AS\n"
+            + "BEGIN\n"
+            + "  SELECT [Case], [End], [When] FROM dbo.Legal\n"
+            + "  SELECT 2\n"
+            + "END\n"
+            + "GO\n"
+            + "CREATE PROCEDURE dbo.p2\n"
+            + "AS\n"
+            + "BEGIN\n"
+            + "  SELECT 3\n"
+            + "END\n"
+            + "GO\n";
+
+    // The DDL keyword on its own line, with the object keyword below it. Legal, and produced by real
+    // exports; line-by-line matching alone does not see it.
+    public static final String SPLIT_DDL_KEYWORD = ""
+            + "CREATE \n"
+            + "procedure [dbo].[split] @a INT as\n"
+            + "BEGIN\n"
+            + "  SELECT 1\n"
+            + "END\n";
+
+    // A temporary stored procedure. The # is part of the name and there is no schema.
+    public static final String TEMPORARY_PROCEDURE = ""
+            + "CREATE PROCEDURE #tempProc @a INT\n"
+            + "AS\n"
+            + "BEGIN\n"
+            + "  SELECT 1\n"
+            + "END\n";
+
+    // A name and an identifier that are not ASCII. Both the name and the complexity count have to treat
+    // a letter such as the Danish o-with-stroke as a word character rather than as a word boundary.
+    public static final String NON_ASCII_IDENTIFIERS = ""
+            + "CREATE PROCEDURE dbo.Opgørelse @a INT\n"
+            + "AS\n"
+            + "BEGIN\n"
+            + "  SET @ANDø = 1\n"
+            + "  SET @ORø = 2\n"
+            + "END\n";
+
+    // A commented-out definition must not be mistaken for a real one.
+    public static final String COMMENTED_OUT_DEFINITION = ""
+            + "-- CREATE PROCEDURE dbo.notreal\n"
+            + "CREATE PROCEDURE dbo.real\n"
+            + "AS\n"
+            + "BEGIN\n"
+            + "  SELECT 1\n"
+            + "END\n";
+}

--- a/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/lang/tsql/TSqlExamples.java
+++ b/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/lang/tsql/TSqlExamples.java
@@ -274,6 +274,64 @@ public class TSqlExamples {
             + "  SET @ORø = 2\n"
             + "END\n";
 
+    // A column aliased with a double-quoted reserved word. T-SQL accepts both delimiter forms, so this
+    // is the same case as [Begin] and has to be masked the same way.
+    public static final String QUOTED_RESERVED_WORD_ALIAS = ""
+            + "CREATE PROCEDURE dbo.p1\n"
+            + "AS\n"
+            + "BEGIN\n"
+            + "  SELECT col AS \"BEGIN\"\n"
+            + "END\n"
+            + "GO\n"
+            + "CREATE PROCEDURE dbo.p2\n"
+            + "AS\n"
+            + "BEGIN\n"
+            + "  SELECT 2\n"
+            + "END\n"
+            + "GO\n";
+
+    // A delimited identifier containing an escaped closing bracket: [Value]]Begin] names Value]Begin.
+    public static final String ESCAPED_BRACKET_IN_IDENTIFIER = ""
+            + "CREATE PROCEDURE dbo.p1\n"
+            + "AS\n"
+            + "BEGIN\n"
+            + "  SELECT [Value]]Begin] FROM dbo.t\n"
+            + "END\n"
+            + "GO\n"
+            + "CREATE PROCEDURE dbo.p2\n"
+            + "AS\n"
+            + "BEGIN\n"
+            + "  SELECT 2\n"
+            + "END\n"
+            + "GO\n";
+
+    // The object's own name contains a bare AS, which must not be read as the end of the signature.
+    public static final String KEYWORD_INSIDE_DELIMITED_NAME = ""
+            + "CREATE PROCEDURE [dbo].[AS]\n"
+            + "@a INT,\n"
+            + "@b INT\n"
+            + "AS\n"
+            + "BEGIN\n"
+            + "  SELECT 1\n"
+            + "END\n";
+
+    // An inline table-valued function written the way they normally are - across several lines.
+    public static final String MULTILINE_INLINE_TVF = ""
+            + "CREATE FUNCTION dbo.f1 (@a INT)\n"
+            + "RETURNS TABLE\n"
+            + "AS\n"
+            + "RETURN\n"
+            + "(\n"
+            + "  SELECT @a AS x\n"
+            + ")\n"
+            + "GO\n"
+            + "CREATE PROCEDURE dbo.p2\n"
+            + "AS\n"
+            + "BEGIN\n"
+            + "  SELECT 2\n"
+            + "END\n"
+            + "GO\n";
+
     // A commented-out definition must not be mistaken for a real one.
     public static final String COMMENTED_OUT_DEFINITION = ""
             + "-- CREATE PROCEDURE dbo.notreal\n"

--- a/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/lang/tsql/TSqlExamples.java
+++ b/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/lang/tsql/TSqlExamples.java
@@ -392,6 +392,25 @@ public class TSqlExamples {
             + "END\n"
             + "GO\n";
 
+    // A bare GO inside a multi-line literal. GO is client-side, so this is valid input - and it is the
+    // accepted cost of treating GO as an unconditional terminator.
+    public static final String GO_INSIDE_A_MULTILINE_LITERAL = ""
+            + "CREATE PROCEDURE dbo.p1\n"
+            + "AS\n"
+            + "BEGIN\n"
+            + "  DECLARE @sql NVARCHAR(MAX) = 'PRINT 1\n"
+            + "GO\n"
+            + "PRINT 2'\n"
+            + "  EXEC sp_executesql @sql\n"
+            + "END\n"
+            + "GO\n"
+            + "CREATE PROCEDURE dbo.p2\n"
+            + "AS\n"
+            + "BEGIN\n"
+            + "  SELECT 2\n"
+            + "END\n"
+            + "GO\n";
+
     // Malformed: the first procedure never closes its BEGIN. The batch separator is all there is to
     // stop it consuming what follows.
     public static final String MISSING_END_BEFORE_GO = ""

--- a/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/lang/tsql/TSqlExamples.java
+++ b/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/lang/tsql/TSqlExamples.java
@@ -340,4 +340,70 @@ public class TSqlExamples {
             + "BEGIN\n"
             + "  SELECT 1\n"
             + "END\n";
+
+    // A literal ending in a backslash - a Windows path, which is routine in maintenance scripts. A
+    // backslash is an ordinary character in T-SQL, so the string ends at the quote that follows it.
+    public static final String BACKSLASH_TERMINATED_STRING = ""
+            + "CREATE PROCEDURE dbo.p1\n"
+            + "AS\n"
+            + "BEGIN\n"
+            + "  DECLARE @path NVARCHAR(200)\n"
+            + "  SET @path = 'D:\\Backups\\'\n"
+            + "END\n"
+            + "GO\n"
+            + "CREATE PROCEDURE dbo.p2\n"
+            + "AS\n"
+            + "BEGIN\n"
+            + "  SELECT 2\n"
+            + "END\n"
+            + "GO\n";
+
+    // T-SQL's actual escape: a quote is doubled inside a literal.
+    public static final String DOUBLED_QUOTE_STRING = ""
+            + "CREATE PROCEDURE dbo.p1\n"
+            + "AS\n"
+            + "BEGIN\n"
+            + "  SELECT 'it''s -- not a comment'\n"
+            + "END\n"
+            + "GO\n"
+            + "CREATE PROCEDURE dbo.p2\n"
+            + "AS\n"
+            + "BEGIN\n"
+            + "  SELECT 2\n"
+            + "END\n"
+            + "GO\n";
+
+    // BEGIN TRANSACTION with the keywords split across lines - legal, and invisible to a line-by-line
+    // scan, so the depth count treats the BEGIN as a block that COMMIT never closes.
+    public static final String BEGIN_TRANSACTION_SPLIT_ACROSS_LINES = ""
+            + "CREATE PROCEDURE dbo.p1\n"
+            + "AS\n"
+            + "BEGIN\n"
+            + "  BEGIN\n"
+            + "  TRANSACTION\n"
+            + "  UPDATE t SET c = 1\n"
+            + "  COMMIT\n"
+            + "END\n"
+            + "GO\n"
+            + "CREATE PROCEDURE dbo.p2\n"
+            + "AS\n"
+            + "BEGIN\n"
+            + "  SELECT 2\n"
+            + "END\n"
+            + "GO\n";
+
+    // Malformed: the first procedure never closes its BEGIN. The batch separator is all there is to
+    // stop it consuming what follows.
+    public static final String MISSING_END_BEFORE_GO = ""
+            + "CREATE PROCEDURE dbo.p1\n"
+            + "AS\n"
+            + "BEGIN\n"
+            + "  SELECT 1\n"
+            + "GO\n"
+            + "CREATE PROCEDURE dbo.p2\n"
+            + "AS\n"
+            + "BEGIN\n"
+            + "  SELECT 2\n"
+            + "END\n"
+            + "GO\n";
 }

--- a/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/units/UnitLineNumbersTest.java
+++ b/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/units/UnitLineNumbersTest.java
@@ -64,6 +64,11 @@ public class UnitLineNumbersTest {
         assertFirstUnit("a.jl", "# comment\nfunction alpha(x)\n    return x\nend\n", 2, 4);
     }
 
+    @Test
+    public void tSqlUnitsAreOnOneBasedFileLines() {
+        assertFirstUnit("a.tsql", "-- comment\nCREATE PROCEDURE dbo.p\nAS\nBEGIN\n  SELECT 1\nEND\n", 2, 6);
+    }
+
     /**
      * The property every extractor must satisfy, stated without naming a specific line: whatever the
      * language, a unit that follows a comment cannot begin on line 1, and cannot end before it starts.
@@ -79,6 +84,7 @@ public class UnitLineNumbersTest {
                 {"a.vb", "' comment\nModule M\n    Sub Alpha()\n        Dim x = 1\n    End Sub\nEnd Module\n"},
                 {"a.lua", "-- comment\nfunction alpha(x)\n  return x\nend\n"},
                 {"a.jl", "# comment\nfunction alpha(x)\n    return x\nend\n"},
+                {"a.tsql", "-- comment\nCREATE PROCEDURE dbo.p\nAS\nBEGIN\n  SELECT 1\nEND\n"},
         };
 
         for (String[] fixture : fixtures) {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -163,6 +163,12 @@ dialects, so the extension alone does not identify the language.
 ```json
 "analyzerOverrides": [
   {
+    "analyzer": "tsql",
+    "filters": [
+      { "pathPattern": ".*/db/procedures/.*[.]sql", "note": "MS T-SQL, not generic SQL" }
+    ]
+  },
+  {
     "analyzer": "plsql",
     "filters": [
       { "pathPattern": ".*/db/packages/.*[.]sql", "note": "Oracle PL/SQL, not generic SQL" }
@@ -171,8 +177,11 @@ dialects, so the extension alone does not identify the language.
 ]
 ```
 
+`.sql` is the case this option exists for: T-SQL, PL/SQL and generic SQL share it, and the
+extension alone cannot say which dialect a file is.
+
 - **`analyzer`** is the *extension key* the analyzer is registered under in
-  `LanguageAnalyzerFactory` — `"plsql"`, `"cs"`, `"java"`, … — not a class name. A key that is
+  `LanguageAnalyzerFactory` — `"tsql"`, `"plsql"`, `"cs"`, `"java"`, … — not a class name. A key that is
   not registered is not reported as an error, and the matched files fall through to the generic
   `DefaultLanguageAnalyzer` rather than to the analyzer their extension would have chosen. A typo
   here therefore leaves the files analysed *less* well than no override at all, so check the key

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -191,6 +191,22 @@ In the example above, `.sql` files under `db/packages/` are analysed as PL/SQL w
 specific files that carry a generic extension: it lives in configuration, survives re-exports,
 and does not require renaming source files.
 
+The same applies to `"tsql"`, for Microsoft T-SQL. It is picked automatically only for the `.tsql`
+extension, because `.sql` is shared with every other dialect and guessing from the extension would
+be wrong as often as right. Server-side code exported from SQL Server arrives as `.sql`, so an
+override is how it is routed:
+
+```json
+"analyzerOverrides": [
+  {
+    "analyzer": "tsql",
+    "filters": [
+      { "pathPattern": ".*/db/procedures/.*[.]sql", "note": "MS T-SQL, not generic SQL" }
+    ]
+  }
+]
+```
+
 ### `fileHistoryAnalysis`
 
 Drives contributor/commit analysis from an exported git history:


### PR DESCRIPTION
`.sql` is shared by every SQL dialect, so T-SQL server-side code currently falls to the generic
`SqlAnalyzer`: no procedures, functions or triggers are recognised as units, and a database of stored
procedures reports no unit sizes and no complexity at all.

This adds a `TSqlAnalyzer` and registers it under a new `tsql` extension key.

### Why a new extension rather than claiming `.sql`

Claiming `.sql` would change how every other dialect is analysed. This mirrors `.plsql`, which the
project already ships for the same reason.

The registration is also what makes T-SQL reachable from `analyzerOverrides`:
`LanguageAnalyzerFactory` passes an override's `analyzer` string straight into the extension lookup, so
the single `analyzersMap` entry both dispatches `.tsql` files and lets a configuration route `.sql`
files at the analyzer:

```json
"analyzerOverrides": [
  { "analyzer": "tsql",
    "filters": [ { "pathPattern": ".*/db/procedures/.*[.]sql", "note": "MS T-SQL, not generic SQL" } ] }
]
```

`docs/configuration.md` now shows that alongside the existing PL/SQL example — `.sql` is the case the
option exists for.

### The extractor

Heuristic, in the house style, not parsing:

- Units start at `CREATE` / `CREATE OR ALTER` / `ALTER` of a `PROCEDURE`, `PROC`, `FUNCTION` or
  `TRIGGER`. The next line is joined in when the first holds nothing but the DDL keyword — real exports
  produce that, and line-by-line matching would miss the unit entirely.
- They end by `BEGIN`/`END` depth, with `CASE` opening a scope and `BEGIN TRY` / `CATCH` / `TRAN` /
  `TRANSACTION` / `DISTRIBUTED TRANSACTION` / `DIALOG` / `CONVERSATION` self-balancing so they do not
  perturb it.
- Wrapping a body in `BEGIN`/`END` is optional in T-SQL, so depth tracking is used only when the body
  opens with its own `BEGIN`. Otherwise the first `BEGIN` belongs to an inner `IF` or `WHILE`, and the
  body runs to the `GO` batch separator instead — closing it at that inner block would drop the rest of
  the procedure from every metric.
- Delimited identifiers are masked before any keyword is counted. `CASE` and `END` are reserved words,
  so `[Case]` and `[End]` are the only way to use them as column names, and unmasked they corrupt the
  depth.
- Names may begin with `#` or `##`, which is how temporary stored procedures are declared.
- Inline table-valued functions have no `BEGIN`/`END` and take a separate path.
- McCabe is classic — no `+1` for `ELSE`.

Keyword matching uses Unicode word characters rather than ASCII ones. Java's `\w`, and therefore `\b`,
is ASCII-only by default, so any non-ASCII letter reads as a word boundary: a Danish identifier ending
in `ø` counted as a branch, and a procedure whose name contained one had that name truncated at the
letter. This extractor is the only one in `lang/` that matches keywords by word boundary rather than by
space-padded literal, so the correction is local to it — and it is consistent with the direction of
\#105, which fixed the same class of problem for the identifier patterns elsewhere.

### Tests

- `TSqlAnalyzerTest` — cleaning, units, complexity, batch handling, delimited identifiers, temporary
  procedure names, and inline table-valued functions.
- `TSqlExamples` — the fixtures, kept separate so the assertions stay readable.
- `UnitLineNumbersTest` gains a T-SQL case, so the new analyzer joins the cross-language check added in
  \#102 rather than asserting one-based line numbers only for itself.
- One test asserts that a `.tsql` file is routed to `TSqlAnalyzer`. Registering an extension is a line
  in a different file from the analyzer it points at and costs nothing at compile time if wrong: the
  file would be read as generic SQL, units still extracted, nothing errors, and the numbers quietly
  those of the wrong dialect.

No T-SQL-specific encoding test is included. SQL Server Management Studio exports UTF-16 LE with a BOM,
and that dependency is real — before BOM-aware reading, such exports decoded as garbage, line counts
survived and every pattern failed, so real exports produced **zero units**. That is covered end to end
by `SourceFileEncodingTest` since #100 and #103, and decoding happens in `SourceFile` before any
analyzer sees a `String`, so a T-SQL copy would assert the same guarantee about the same code path.

### Verification

Branch is merged up to current `master`; `mvn clean install` is green — all modules, including the
non-ASCII identifier tests from #105 and the encoding tests from #103.
