### PR TITLE
Read a backslash as an ordinary character in PL/SQL string literals

### DIFF
--- a/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/lang/plsql/PlSqlAnalyzer.java
+++ b/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/lang/plsql/PlSqlAnalyzer.java
@@ -48,7 +48,15 @@ public class PlSqlAnalyzer extends LanguageAnalyzer {
 
         cleaner.addCommentBlockHelper("/*", "*/");
         cleaner.addCommentBlockHelper("--", "\n");
-        cleaner.addStringBlockHelper("'", "\\");
+        // PL/SQL escapes a quote by doubling it ('I''m'), and a backslash is an ordinary character with
+        // no special meaning in a string literal. Naming backslash as the escape marker misreads any
+        // literal ending in one - 'C:\exports\', a routine path for UTL_FILE work - as an escaped
+        // quote, so the parser runs on to the next quote in the file. Every literal after that point is
+        // paired with the wrong partner, and the tail of the file is dropped from the cleaned content
+        // entirely: lines of code are undercounted and unit boundaries understated, with nothing in the
+        // report to say so. Passing the quote as its own escape marker is what CodeBlockParser reads as
+        // the doubling rule.
+        cleaner.addStringBlockHelper("'", "'");
 
         return cleaner;
     }

--- a/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/lang/plsql/PlSqlAnalyzerTest.java
+++ b/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/lang/plsql/PlSqlAnalyzerTest.java
@@ -105,4 +105,56 @@ public class PlSqlAnalyzerTest {
         assertEquals(0, unitInfos.get(0).getNumberOfParameters());
     }
 
+    /**
+     * A backslash carries no special meaning in a PL/SQL string literal, so a path ending in one must
+     * not be read as an escaped quote. When it was, every literal after that point paired with the
+     * wrong partner and the tail of the file was dropped from the cleaned content - here the last two
+     * lines, so the file measured 10 lines of code instead of 12.
+     */
+    @Test
+    public void cleanForLinesOfCodeCalculations_keepsTheTailAfterALiteralEndingInABackslash() {
+        SourceFile sourceFile = new SourceFile(new File("test_backslash.pls"),
+                PlSqlExamples.CONTENT_BACKSLASH_PATH);
+
+        CleanedContent cleanedContent = analyzer.cleanForLinesOfCodeCalculations(sourceFile);
+
+        assertTrue(cleanedContent.getCleanedContent().contains("END export_pkg;"),
+                () -> "the end of the package must survive cleaning, got:\n" + cleanedContent.getCleanedContent());
+        assertEquals(12, cleanedContent.getCleanedLinesCount());
+    }
+
+    /**
+     * The same defect measured on the other consumer of the cleaner. Asserting only the line count
+     * would leave unit boundaries untested, and they move too: the last procedure lost its END line.
+     */
+    @Test
+    public void extractUnits_aLiteralEndingInABackslashDoesNotShortenTheUnitsAfterIt() {
+        SourceFile sourceFile = new SourceFile(new File("test_backslash_units.pls"),
+                PlSqlExamples.CONTENT_BACKSLASH_PATH);
+
+        List<UnitInfo> unitInfos = analyzer.extractUnits(sourceFile);
+
+        assertEquals(2, unitInfos.size());
+        assertEquals("write_report", unitInfos.get(0).getShortName());
+        assertEquals("archive", unitInfos.get(1).getShortName());
+        // Runs to its own END on line 11, not to the line before it.
+        assertEquals(4, unitInfos.get(1).getLinesOfCode());
+    }
+
+    /**
+     * PL/SQL's actual escape, which the fix relies on: a quote is doubled inside a literal. Passes
+     * against either escape marker, so this pins the semantics rather than guarding the defect.
+     */
+    @Test
+    public void cleanForLinesOfCodeCalculations_handlesADoubledQuote() {
+        SourceFile sourceFile = new SourceFile(new File("test_doubled.pls"),
+                "BEGIN\n  introduction := ' Hello! I''m John Smith.';\n  choice := 'y';\nEND;\n");
+
+        CleanedContent cleanedContent = analyzer.cleanForLinesOfCodeCalculations(sourceFile);
+
+        assertTrue(cleanedContent.getCleanedContent().contains("choice := 'y'"),
+                () -> "the statement after the doubled quote must survive, got:\n"
+                        + cleanedContent.getCleanedContent());
+    }
+
 }

--- a/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/lang/plsql/PlSqlExamples.java
+++ b/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/lang/plsql/PlSqlExamples.java
@@ -286,4 +286,19 @@ public static final String CONTENT_10 = "package gf_BI is\n" +
             "\n" +
             "end gf_BI;\n" +
             "/\n";
+
+    // A literal ending in a backslash - a Windows path, routine in UTL_FILE work. A backslash carries
+    // no special meaning in a PL/SQL literal, so the string ends at the quote right after it.
+    public static final String CONTENT_BACKSLASH_PATH = "CREATE OR REPLACE PACKAGE BODY export_pkg AS\n" +
+            "  PROCEDURE write_report(p_name IN VARCHAR2) IS\n" +
+            "    v_dir VARCHAR2(200);\n" +
+            "  BEGIN\n" +
+            "    v_dir := 'C:\\exports\\';\n" +
+            "    dbms_output.put_line(v_dir || p_name);\n" +
+            "  END write_report;\n" +
+            "  PROCEDURE archive(p_id IN NUMBER) IS\n" +
+            "  BEGIN\n" +
+            "    dbms_output.put_line('archiving');\n" +
+            "  END archive;\n" +
+            "END export_pkg;\n";
 }


### PR DESCRIPTION
PlSqlAnalyzer registered the string helper as addStringBlockHelper("'", "\\"), naming backslash as the quote-escape marker. PL/SQL escapes a quote by doubling it; a backslash carries no special meaning in a literal.

So a literal ending in one — 'C:\exports\', a routine path for UTL_FILE work — is read as an escaped quote, and the parser runs on to the next quote in the file. Every literal after that point pairs with the wrong partner, and the tail of the file is dropped from the cleaned content when the last one is left unterminated.

Measured on the fixture added here (a package body with two procedures): the file cleans to 10 lines instead of 12, and the second procedure measures 4 lines of code instead of 5 — its END line is gone. Both figures are silently wrong; nothing in the report indicates the file was truncated. A larger file loses correspondingly more, and a procedure that falls entirely past the truncation point is not extracted at all.

Passing the quote as its own escape marker is the doubling rule CodeBlockParser already implements: when escapeMarker equals endMarker it sets ignoreEscapedEscapeMarker and treats '' as the escape, which is exactly PL/SQL's semantics.

Three tests: two regression tests covering the line count and unit boundaries separately, since the cleaner feeds both and asserting one would leave the other untested; both were mutation-checked by reverting the fix and confirming they fail. The third pins the doubled-quote semantics the fix relies on — it passes against either marker, so it is characterisation rather than a guard, and is labelled as such.

Full codeanalyzer suite green: 548 tests.