### PR TITLE
Resolve buildAndDeployment, and generated, in CodeConfiguration.getScope

### DIFF
--- a/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/core/CodeConfiguration.java
+++ b/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/core/CodeConfiguration.java
@@ -436,6 +436,15 @@ public class CodeConfiguration {
         this.tagRules = tagRules;
     }
 
+    /**
+     * The scope aspect a configured name refers to.
+     *
+     * <p>Labels are lower case because the subject is: a mixed-case label such as
+     * {@code "buildAndDeployment"} can never match {@code scope.toLowerCase()}, which is what left
+     * that scope - and {@code generated}, which had no case at all - falling through to {@code main}.
+     * Both then looked like real aspects, so a decomposition scoped to either one silently decomposed
+     * main instead.
+     */
     @JsonIgnore
     public NamedSourceCodeAspect getScope(String scope) {
         switch (scope.toLowerCase()) {
@@ -443,7 +452,9 @@ public class CodeConfiguration {
                 return main;
             case "test":
                 return test;
-            case "buildAndDeployment":
+            case "generated":
+                return generated;
+            case "buildanddeployment":
                 return buildAndDeployment;
             case "other":
                 return other;

--- a/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/CodeConfigurationTest.java
+++ b/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/CodeConfigurationTest.java
@@ -4,11 +4,13 @@
 
 package nl.obren.sokrates.sourcecode;
 
+import nl.obren.sokrates.sourcecode.aspects.LogicalDecomposition;
 import nl.obren.sokrates.sourcecode.aspects.NamedSourceCodeAspect;
 import nl.obren.sokrates.sourcecode.core.CodeConfiguration;
 import org.junit.Test;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -62,6 +64,65 @@ public class CodeConfigurationTest {
 
         codeConfiguration.setLogicalDecompositions(null);
         assertNotNull(codeConfiguration.getLogicalDecompositions());
+    }
+
+    /**
+     * Every scope name resolves to its own aspect.
+     *
+     * <p>Asserted by object identity against {@code getMain()} as well as by name, because the failure
+     * this guards returned a real aspect - main - rather than null. A name-only assertion would have
+     * passed for {@code getScope("main")} while the other two were quietly answering with it.
+     */
+    @Test
+    public void getScopeReturnsTheAspectEachNameRefersTo() {
+        CodeConfiguration codeConfiguration = CodeConfiguration.getDefaultConfiguration();
+
+        assertSame(codeConfiguration.getMain(), codeConfiguration.getScope("main"));
+        assertSame(codeConfiguration.getTest(), codeConfiguration.getScope("test"));
+        assertSame(codeConfiguration.getGenerated(), codeConfiguration.getScope("generated"));
+        assertSame(codeConfiguration.getBuildAndDeployment(), codeConfiguration.getScope("buildAndDeployment"));
+        assertSame(codeConfiguration.getOther(), codeConfiguration.getScope("other"));
+    }
+
+    /**
+     * The name is matched case-insensitively, which is why the labels it is matched against have to be
+     * lower case. {@code "buildAndDeployment"} is the spelling the configuration documentation uses,
+     * so it is the one that has to work.
+     */
+    @Test
+    public void getScopeIgnoresTheCaseOfTheName() {
+        CodeConfiguration codeConfiguration = CodeConfiguration.getDefaultConfiguration();
+
+        assertSame(codeConfiguration.getBuildAndDeployment(), codeConfiguration.getScope("buildAndDeployment"));
+        assertSame(codeConfiguration.getBuildAndDeployment(), codeConfiguration.getScope("BUILDANDDEPLOYMENT"));
+        assertSame(codeConfiguration.getGenerated(), codeConfiguration.getScope("GeNeRaTeD"));
+    }
+
+    /**
+     * The end-to-end consequence, and the reason this is not a latent defect: a logical decomposition
+     * reads its files through {@code getScope(scope)}, so a decomposition scoped to {@code generated}
+     * used to decompose main instead — including the main files and excluding the generated ones,
+     * exactly inverted.
+     */
+    @Test
+    public void aLogicalDecompositionScopedToGeneratedDecomposesGeneratedFiles() {
+        SourceFile mainFile = new SourceFile(new File("src/main/java/App.java"));
+        SourceFile generatedFile = new SourceFile(new File("target/generated/Stub.java"));
+
+        CodeConfiguration codeConfiguration = CodeConfiguration.getDefaultConfiguration();
+        codeConfiguration.getMain().setSourceFiles(new ArrayList<>(Arrays.asList(mainFile)));
+        codeConfiguration.getGenerated().setSourceFiles(new ArrayList<>(Arrays.asList(generatedFile)));
+
+        LogicalDecomposition decomposition = new LogicalDecomposition();
+        decomposition.setName("by scope");
+        decomposition.setScope("generated");
+        decomposition.setComponentsFolderDepth(0);
+        decomposition.setComponents(new ArrayList<>());
+
+        decomposition.updateLogicalComponentsFiles(new SourceCodeFiles(), codeConfiguration, new File("."));
+
+        assertTrue(decomposition.isInScope(generatedFile));
+        assertFalse(decomposition.isInScope(mainFile));
     }
 
 }


### PR DESCRIPTION
getScope switches on scope.toLowerCase(), so `case "buildAndDeployment"` can never match — the subject is always lower case by the time it is compared. The name is unreachable, and falls through to `return main`.

This is not latent. LogicalDecomposition reads its files through codeConfiguration.getScope(scope), at two call sites present since the first commit, so a decomposition configured with that scope silently decomposes main instead. It does not fail, warn, or come back empty — it produces a plausible decomposition of the wrong files.

Measured end to end with generateReports on a six-file repository — four .java under src/, two pom.xml at the root and under deploy/ — configured with two decompositions, `primary` scoped to main and `build_view` scoped to buildAndDeployment:

    decomposition               before                     after
    primary (main)              src: 4 files, 16 LOC       src: 4 files, 16 LOC
    build_view (build)          src: 4 files, 16 LOC       deploy: 1 file
                                                           ROOT:   1 file

`build_view` reported the Java source, identical to `primary`. The two pom.xml files it was scoped to appeared nowhere, in analysisResults.json or in the rendered Components.html. Nothing was logged: the run exits 0 with a complete report.

It is least visible when it matters most. With the default componentsFolderDepth of 1, both decompositions render the same component names side by side, which reads as "the build files live in the same folders" rather than as a copy. Since main is commonly `.*`, a decomposition scoped to anything else generally shows the whole repository.

`generated` is a separate question, and I would rather ask it than assume.

It had no case at all, so it behaves the same way — today `getScope("generated")` hands back main's files. That is wrong under any reading, which is why it is changed here rather than left. But whether generated *should* be decomposable is yours to say: the configuration manual describes logicalDecompositions as "Groups `main` files into components and renders their dependencies", so it is fair to read decomposition as a main-code concept. If it is, the right answer for generated is to reject the name rather than to resolve it — but not to keep substituting a different scope's files, which is what happens now.

Two things I have deliberately not decided:

  - An unrecognised name still returns main. Returning null would close every misspelling at once, including the buildAndDeployment aspect's own display name "build and deployment" (with spaces), which a user can read out of their own config.json and which still falls through. But null would throw at the two LogicalDecomposition call sites above, so it is a change of contract rather than a bug fix, and it is yours to make. Rejecting unknown names at load time, with the name in the message, is a third option.
  - Whether generated belongs in the list at all, per the paragraph above.

Anyone whose configuration already sets a decomposition scope to buildAndDeployment or generated will see that decomposition change, because it starts measuring what it was pointed at.

Labels are now lower case to match the lower-cased subject, and generated has a case of its own. Three tests: the two direct ones assert object identity against the getters rather than names, because the failure returned main rather than null and a name-only assertion would have passed while two scopes quietly answered with it; the third pins the end-to-end consequence through LogicalDecomposition. All three were mutation-checked by restoring the original cases and confirming they fail.

Full build green.