### PR TITLE
Evaluate each distinct path/pattern slash combination once

### DIFF
--- a/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/SourceFileFilter.java
+++ b/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/SourceFileFilter.java
@@ -123,17 +123,33 @@ public class SourceFileFilter {
     }
 
     public boolean pathMatches(String path) {
-        boolean pathMatches;
-        if (StringUtils.isNotBlank(pathPattern)) {
-            pathMatches = RegexUtils.matchesEntirely(pathPattern, path)
-                    || RegexUtils.matchesEntirely(pathPattern, path.replace("\\", "/"))
-                    || RegexUtils.matchesEntirely(pathPattern, path.replace("/", "\\"))
-                    || RegexUtils.matchesEntirely(pathPattern.replace("\\", "/"), path.replace("\\", "/"))
-                    || RegexUtils.matchesEntirely(pathPattern.replace("\\", "/"), path.replace("/", "\\"));
-        } else {
-            pathMatches = true;
+        if (StringUtils.isBlank(pathPattern)) {
+            return true;
         }
-        return pathMatches;
+
+        // A filter written with one slash style must also match paths written with the other, so five
+        // (pattern, path) combinations are tried: the path as given, with "\" replaced by "/", and
+        // with "/" replaced by "\", each against the pattern as given and with "\" replaced by "/".
+        // A combination repeats another whenever the string it rewrites holds no such separator - for
+        // a path and a pattern that contain no backslash (the common case: every git path, and every
+        // path on Linux and macOS) the five collapse to at most two distinct pairs. Testing for the
+        // separator before rewriting evaluates each distinct pair once; which pairs are matched is
+        // unchanged.
+        if (RegexUtils.matchesEntirely(pathPattern, path)) {
+            return true;
+        }
+        if (path.contains("\\") && RegexUtils.matchesEntirely(pathPattern, path.replace("\\", "/"))) {
+            return true;
+        }
+        if (path.contains("/") && RegexUtils.matchesEntirely(pathPattern, path.replace("/", "\\"))) {
+            return true;
+        }
+        if (pathPattern.contains("\\")) {
+            String pathPatternWithForwardSlashes = pathPattern.replace("\\", "/");
+            return RegexUtils.matchesEntirely(pathPatternWithForwardSlashes, path.replace("\\", "/"))
+                    || RegexUtils.matchesEntirely(pathPatternWithForwardSlashes, path.replace("/", "\\"));
+        }
+        return false;
     }
 
     boolean contentMatches(List<String> lines) {

--- a/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/SourceFileFilterTest.java
+++ b/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/SourceFileFilterTest.java
@@ -26,6 +26,32 @@ public class SourceFileFilterTest {
     }
 
     @Test
+    public void testPathMatchesPatternWithForwardSlashes() {
+        // The pattern is also tried with "\" replaced by "/". Here the pattern is the regex a\.b
+        // (a, any character, b): only the pattern rewritten to a/.b matches the path a/1b.
+        assertTrue(new SourceFileFilter("a\\.b", "").pathMatches("a/1b"));
+        assertFalse(new SourceFileFilter("a\\.b", "").pathMatches("a/1c"));
+    }
+
+    @Test
+    public void testPathMatchesPathWithBackSlashes() {
+        // The path is also tried with "/" replaced by "\", so a pattern that excludes forward
+        // slashes still matches a path that contains them.
+        assertTrue(new SourceFileFilter("[^/]*[.]java", "").pathMatches("comp1/src/Test.java"));
+        assertFalse(new SourceFileFilter("[^/]*[.]java", "").pathMatches("comp1/src/Test.html"));
+    }
+
+    @Test
+    public void testPathMatchesPatternWithForwardSlashesAndPathWithBackSlashes() {
+        // The pattern rewritten to forward slashes is also tried against the path rewritten to
+        // backslashes. Here the pattern is the regex [^\/]ab (one character that is neither a backslash
+        // nor a slash, then ab): only the pattern rewritten to [^//]ab, against the path rewritten to
+        // \ab, matches - the path alone or the pattern alone still has a separator the class rejects.
+        assertTrue(new SourceFileFilter("[^\\\\/]ab", "").pathMatches("/ab"));
+        assertFalse(new SourceFileFilter("[^\\\\/]ab", "").pathMatches("/ac"));
+    }
+
+    @Test
     public void testToString() {
         assertEquals(new SourceFileFilter("a", "").toString(), "path like \"a\"");
         assertEquals(new SourceFileFilter("", "b").toString(), "content like \"b\"");


### PR DESCRIPTION
pathMatches tried five combinations of the path and the pattern with the slashes rewritten, so that a filter written with one slash style matches paths written with the other. Several of those are the same (pattern, path) pair: rewriting a string that holds no such separator returns it unchanged. For a path and a pattern without a backslash - every git path, and every path on Linux and macOS - the five collapse to two, and the same regex was matched against the same string up to three times.

Testing for the separator before rewriting evaluates each distinct pair once. Which pairs are matched is unchanged; a cross-product of the standard scoping conventions (520 path patterns) and two patterns written with backslashes against 2799 paths, in POSIX, Windows and mixed spellings, agrees with the previous code on all 1461078 outcomes.

Matching one path against the standard conventions drops from 1.00 ms to 0.45 ms, and "sokrates init" over a 932-file repository from 2.89 s to 1.85 s (medians of 5 runs); the generated config.json is byte-identical.

Three tests are added. Two pin combinations that no test covered: the pattern rewritten to forward slashes, and that pattern against the path rewritten to backslashes; the test reaches the latter with a character class that excludes both separators, so that neither the pattern nor the path alone is enough. The third states the effect of rewriting the path to backslashes, which testPathMatches already pins; the case it documents is the reason the evaluation cannot be reduced further. All three describe existing behaviour and pass on the previous code as well.