### PR TITLE
Name the scope file lists in all_files.zip after the aspects

### DIFF
--- a/reports/src/main/java/nl/obren/sokrates/reports/dataexporters/DataExporter.java
+++ b/reports/src/main/java/nl/obren/sokrates/reports/dataexporters/DataExporter.java
@@ -681,13 +681,7 @@ public class DataExporter {
             File zipFolder = new File(dataFolder, "zips");
             zipFolder.mkdirs();
 
-            ZipUtils.stringToZipFile(new File(zipFolder, "all_files.zip"), new String[][]{
-                    {"aspect_main.txt", FileUtils.readFileToString(new File(textDataFolder, "aspect_main.txt"), UTF_8)},
-                    {"aspect_test.txt", FileUtils.readFileToString(new File(textDataFolder, "aspect_test.txt"), UTF_8)},
-                    {"aspect_generated.txt", FileUtils.readFileToString(new File(textDataFolder, "aspect_generated.txt"), UTF_8)},
-                    {"aspect_build_and_deployment.txt", FileUtils.readFileToString(new File(textDataFolder, "aspect_build_and_deployment.txt"), UTF_8)},
-                    {"aspect_other.txt", FileUtils.readFileToString(new File(textDataFolder, "aspect_other.txt"), UTF_8)}
-            });
+            ZipUtils.stringToZipFile(new File(zipFolder, "all_files.zip"), aspectFileLists(codeConfiguration, textDataFolder));
             File gitHistoryFile = new File(reportsFolder, "../../git-history.txt");
             if (gitHistoryFile.exists()) {
                 // Stream the file into the zip; on huge repositories git-history.txt can exceed the
@@ -697,6 +691,30 @@ public class DataExporter {
         } catch (Throwable t) {
             t.printStackTrace();
         }
+    }
+
+    /**
+     * The five scope file lists, named the way they were written.
+     *
+     * <p>These were five literals - "aspect_main.txt" and so on - which is what the default aspect
+     * names produce. The writer derives each name from the aspect's configured name, so renaming a
+     * scope aspect in config.json left this opening a file nothing had written; the exception went
+     * into the enclosing catch in the caller, taking the rest of that block with it.
+     *
+     * <p>Derived through the writer's own function rather than by repeating its rule, so the two
+     * cannot drift apart again.
+     */
+    static String[][] aspectFileLists(CodeConfiguration configuration, File textDataFolder) throws IOException {
+        List<NamedSourceCodeAspect> aspects = Arrays.asList(
+                configuration.getMain(), configuration.getTest(), configuration.getGenerated(),
+                configuration.getBuildAndDeployment(), configuration.getOther());
+
+        String[][] entries = new String[aspects.size()][2];
+        for (int i = 0; i < aspects.size(); i++) {
+            String fileName = DataExportUtils.getAspectFileListFileName(aspects.get(i), "");
+            entries[i] = new String[]{fileName, FileUtils.readFileToString(new File(textDataFolder, fileName), UTF_8)};
+        }
+        return entries;
     }
 
     public File getTextDataFolder() {

--- a/reports/src/test/java/nl/obren/sokrates/reports/dataexporters/DataExporterAspectFileListsTest.java
+++ b/reports/src/test/java/nl/obren/sokrates/reports/dataexporters/DataExporterAspectFileListsTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2021 Željko Obrenović. All rights reserved.
+ */
+
+package nl.obren.sokrates.reports.dataexporters;
+
+import nl.obren.sokrates.sourcecode.aspects.NamedSourceCodeAspect;
+import nl.obren.sokrates.sourcecode.core.CodeConfiguration;
+import org.apache.commons.io.FileUtils;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * The five scope file lists that go into all_files.zip are named by the aspects, not by five literals.
+ *
+ * <p>The literals and the default names agree, which is why the difference stayed invisible: it appears
+ * only once somebody renames a scope aspect in config.json, which the configuration model allows.
+ */
+public class DataExporterAspectFileListsTest {
+
+    @Test
+    public void theDefaultAspectNamesProduceTheHistoricalFileNames() throws Exception {
+        // The regression guard. Every existing repository uses these names, and a fix that derived
+        // something subtly different - "aspect_build_and_deployment" is getSafeFileName's doing, not an
+        // obvious transformation of "build and deployment" - would change what every report contains.
+        CodeConfiguration configuration = CodeConfiguration.getDefaultConfiguration();
+        File folder = writeFileListsFor(configuration);
+
+        List<String> names = namesOf(DataExporter.aspectFileLists(configuration, folder));
+
+        assertEquals("[aspect_main.txt, aspect_test.txt, aspect_generated.txt, "
+                + "aspect_build_and_deployment.txt, aspect_other.txt]", names.toString());
+    }
+
+    @Test
+    public void aRenamedScopeAspectIsReadUnderTheNameItWasWrittenWith() throws Exception {
+        // Before this, the read was a literal: a rename left it opening a file nothing had written, the
+        // NoSuchFileException went into the enclosing catch, and the rest of that block went with it -
+        // costing all_files.zip and git-history.zip while the report still exited 0.
+        CodeConfiguration configuration = CodeConfiguration.getDefaultConfiguration();
+        configuration.getBuildAndDeployment().setName("buildAndDeployment");
+        File folder = writeFileListsFor(configuration);
+
+        List<String> names = namesOf(DataExporter.aspectFileLists(configuration, folder));
+
+        assertEquals("[aspect_main.txt, aspect_test.txt, aspect_generated.txt, "
+                + "aspect_buildAndDeployment.txt, aspect_other.txt]", names.toString());
+    }
+
+    @Test
+    public void theContentOfEachFileIsCarriedIntoTheEntry() throws Exception {
+        // Names alone would pass while the zip carried empty entries.
+        CodeConfiguration configuration = CodeConfiguration.getDefaultConfiguration();
+        File folder = writeFileListsFor(configuration);
+
+        String[][] entries = DataExporter.aspectFileLists(configuration, folder);
+
+        assertEquals("contents of aspect_main.txt", entries[0][1]);
+    }
+
+    /** A text folder holding exactly the files the exporter writes for this configuration. */
+    private File writeFileListsFor(CodeConfiguration configuration) throws IOException {
+        File folder = Files.createTempDirectory("aspect-file-lists").toFile();
+        folder.deleteOnExit();
+        for (NamedSourceCodeAspect aspect : new NamedSourceCodeAspect[]{
+                configuration.getMain(), configuration.getTest(), configuration.getGenerated(),
+                configuration.getBuildAndDeployment(), configuration.getOther()}) {
+            String name = DataExportUtils.getAspectFileListFileName(aspect, "");
+            FileUtils.write(new File(folder, name), "contents of " + name, StandardCharsets.UTF_8);
+        }
+        return folder;
+    }
+
+    private List<String> namesOf(String[][] entries) {
+        List<String> names = new ArrayList<>();
+        for (String[] entry : entries) {
+            names.add(entry[0]);
+        }
+        return names;
+    }
+}


### PR DESCRIPTION
**Renaming a scope aspect in `config.json` silently costs the report two files** — `zips/all_files.zip` and `zips/git-history.zip` are both missing from `data.zip`, and the run still exits `0` with no message a user would notice.

This fixes it by reading those file lists under the names they were **written** with, rather than under five hard-coded literals. Default configurations are unaffected: their entry names come out exactly as before.

## How it happens

`DataExporter` reads the five scope file lists by literal name:

```java
{"aspect_build_and_deployment.txt", FileUtils.readFileToString(new File(textDataFolder, "aspect_build_and_deployment.txt"), UTF_8)},
```

but the writer derives each name from the aspect's **configured** name, via `DataExportUtils.getAspectFileListFileName` → `getSafeFileName(prefix + name)`. The default names produce exactly those five literals, so the two sides agree in every ordinary report and the difference is invisible — until someone renames an aspect. Then the read opens a file nothing wrote, the `NoSuchFileException` lands in the enclosing `catch (Throwable t) { t.printStackTrace(); }`, and every later statement in that block is skipped. `git-history.zip` is collateral: it is written a few lines below.

Renaming is an ordinary thing to do — `name` is a documented field of each scope aspect, and `init` writes `"build and deployment"` while the JSON key beside it reads `buildAndDeployment`, so "make the name match the key" is a natural edit.

## Measured

Two fixtures, identical but for `buildAndDeployment.name`:

| `buildAndDeployment.name` | exceptions | zips in `data.zip` | | --- | --- | --- |
| `build and deployment` (what `init` writes) | 0 | `all_files.zip`, `git-history.zip` | | `buildAndDeployment` (renamed) | 1 | **none** |

After this change the renamed fixture produces both zips with 0 exceptions.

## Why it is safe for existing reports

- **The default configuration's entry names are unchanged** — `aspect_main.txt`, `aspect_test.txt`, `aspect_generated.txt`, `aspect_build_and_deployment.txt`, `aspect_other.txt`, in that order. A test asserts that against hard-coded literals rather than against the deriving function, so it cannot pass by agreeing with itself.
- **The entry names now follow the configuration**, visible only to someone who renamed an aspect and downloads the zip. The one consumer is the download link in `ReportFileExporter`; nothing parses those names.
- The loose `data/text/aspect_<safe name>.txt` files were never affected — those already follow the configuration.
- Names are derived through the writer's own function rather than by repeating its rule, so the two cannot drift apart again.

## Tests

Three, in a new `DataExporterAspectFileListsTest`: the default names produce the historical five, a renamed aspect is read under the name it was written with, and each entry carries its file's content. Each was checked by mutation — taking the name from `getName()`, emitting empty content, and dropping an aspect from the list each fail at least one.

## Two things I did not do, and would rather raise than fold in

1. **The `catch (Throwable)`** is what turned a missing file into a silent partial export. Removing the trigger fixes this case; an export step that fails still leaves a report that looks complete and exits 0. Worth its own decision.
2. **`LandscapeAnalyzer.getRepositoryFiles` reads those same five names as literals** from each repository's `data.zip`. A renamed aspect costs the landscape that scope's files too — and more quietly, since a missing entry reads as `null` and the scope contributes an empty list with no exception. Same defect, different module. I have not measured that one end to end, so I have deliberately not touched it here.