### PR TITLE
Export every analysed co-change window, and none that was skipped

### DIFF
--- a/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/analysis/files/FileHistoryAnalyzer.java
+++ b/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/analysis/files/FileHistoryAnalyzer.java
@@ -9,6 +9,7 @@ import nl.obren.sokrates.sourcecode.analysis.Analyzer;
 import nl.obren.sokrates.sourcecode.analysis.results.CodeAnalysisResults;
 import nl.obren.sokrates.sourcecode.analysis.results.FileAgeDistributionPerLogicalDecomposition;
 import nl.obren.sokrates.sourcecode.analysis.results.FilesHistoryAnalysisResults;
+import nl.obren.sokrates.sourcecode.analysis.results.TemporalDependenciesWindow;
 import nl.obren.sokrates.sourcecode.aspects.LogicalDecomposition;
 import nl.obren.sokrates.sourcecode.core.CodeConfiguration;
 import nl.obren.sokrates.sourcecode.filehistory.*;
@@ -55,19 +56,24 @@ public class FileHistoryAnalyzer extends Analyzer {
                 LOG.info("Analyzing file age...");
                 analyzeFilesAge();
                 int maxDays = codeConfiguration.getAnalysis().getMaxTemporalDependenciesDepthDays();
-                if (maxDays > 180) {
+                // Named up front: a window that is not listed here produces an empty result for that
+                // reason alone, and only the absence of its "Analyzing..." line would otherwise say so.
+                LOG.info("Co-change windows at maxTemporalDependenciesDepthDays=" + maxDays + ": "
+                        + TemporalDependenciesWindow.analyzedWindows(analysisResults, maxDays)
+                        + " (the others are not analyzed)");
+                if (TemporalDependenciesWindow.ALL_TIME.isAnalyzed(maxDays)) {
                     LOG.info("Analyzing files changed together (all time=" + maxDays + " days)...");
                     analyzeFilesChangedTogether(history);
                 }
-                if (maxDays >= 30) {
+                if (TemporalDependenciesWindow.PAST_30_DAYS.isAnalyzed(maxDays)) {
                     LOG.info("Analyzing files changed together in past 30 days...");
                     analyzeFilesChangedTogether30Days(history);
                 }
-                if (maxDays >= 90) {
+                if (TemporalDependenciesWindow.PAST_90_DAYS.isAnalyzed(maxDays)) {
                     LOG.info("Analyzing files changed together in past 90 days...");
                     analyzeFilesChangedTogether90Days(history);
                 }
-                if (maxDays >= 180) {
+                if (TemporalDependenciesWindow.PAST_180_DAYS.isAnalyzed(maxDays)) {
                     LOG.info("Analyzing files changed together in past 180 days...");
                     analyzeFilesChangedTogether180Days(history);
                 }

--- a/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/analysis/results/FilesHistoryAnalysisResults.java
+++ b/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/analysis/results/FilesHistoryAnalysisResults.java
@@ -260,6 +260,15 @@ public class FilesHistoryAnalysisResults {
         }).collect(Collectors.toCollection(ArrayList::new));
     }
 
+    /**
+     * True if any commit history was imported. When false, none of the co-change windows were
+     * analyzed, so their (empty) results say nothing about the code.
+     */
+    @JsonIgnore
+    public boolean hasHistory() {
+        return history.size() > 0;
+    }
+
     @JsonIgnore
     public List<FileModificationHistory> getHistory(int maxHistoryLength) {
         return history.stream().limit(maxHistoryLength).collect(Collectors.toList());

--- a/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/analysis/results/TemporalDependenciesWindow.java
+++ b/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/analysis/results/TemporalDependenciesWindow.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2021 Željko Obrenović. All rights reserved.
+ */
+
+package nl.obren.sokrates.sourcecode.analysis.results;
+
+import nl.obren.sokrates.sourcecode.filehistory.FilePairChangedTogether;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * The "files changed together" (co-change) windows that FileHistoryAnalyzer computes, and the
+ * condition under which each one is computed for a given maxTemporalDependenciesDepthDays.
+ *
+ * <p>The analyzer runs a window only when the configured depth reaches it, so at a depth of e.g. 90
+ * days the 180-day and all-time results are never populated. Consumers - the data exporter and the
+ * temporal dependencies report - must ask the same question before presenting a window, otherwise a
+ * window that was never analyzed is indistinguishable from one that was analyzed and found nothing.
+ *
+ * <p>The predicates mirror the branches in FileHistoryAnalyzer.analyze();
+ * TemporalDependenciesWindowTest pins them to the analyzer so the two cannot drift.
+ */
+public enum TemporalDependenciesWindow {
+    PAST_30_DAYS("30_days", "_30_days", 30, true, FilesHistoryAnalysisResults::getFilePairsChangedTogether30Days),
+    PAST_90_DAYS("90_days", "_90_days", 90, true, FilesHistoryAnalysisResults::getFilePairsChangedTogether90Days),
+    PAST_180_DAYS("180_days", "_180_days", 180, true, FilesHistoryAnalysisResults::getFilePairsChangedTogether180Days),
+    // The all-time window is only worth computing when the configured depth is strictly wider than
+    // the fixed 180-day window; at exactly 180 days it would duplicate PAST_180_DAYS.
+    ALL_TIME("all_time", "", 180, false, FilesHistoryAnalysisResults::getFilePairsChangedTogether);
+
+    private final String id;
+    private final String fileNameSuffix;
+    private final int depthDays;
+    private final boolean inclusive;
+    private final Function<FilesHistoryAnalysisResults, List<FilePairChangedTogether>> accessor;
+
+    TemporalDependenciesWindow(String id, String fileNameSuffix, int depthDays, boolean inclusive,
+                               Function<FilesHistoryAnalysisResults, List<FilePairChangedTogether>> accessor) {
+        this.id = id;
+        this.fileNameSuffix = fileNameSuffix;
+        this.depthDays = depthDays;
+        this.inclusive = inclusive;
+        this.accessor = accessor;
+    }
+
+    /**
+     * The tab id used in the temporal dependencies report, and the suffix identifying the window
+     * elsewhere (e.g. in visualisation file names).
+     */
+    public String getId() {
+        return id;
+    }
+
+    public int getDepthDays() {
+        return depthDays;
+    }
+
+    /**
+     * True if FileHistoryAnalyzer computes this window at the given configured depth.
+     */
+    public boolean isAnalyzed(int maxTemporalDependenciesDepthDays) {
+        return inclusive
+                ? maxTemporalDependenciesDepthDays >= depthDays
+                : maxTemporalDependenciesDepthDays > depthDays;
+    }
+
+    public List<FilePairChangedTogether> getFilePairs(FilesHistoryAnalysisResults results) {
+        return accessor.apply(results);
+    }
+
+    public String getDataFileName() {
+        return "temporal_dependencies" + fileNameSuffix + ".txt";
+    }
+
+    public String getDifferentFoldersDataFileName() {
+        return "temporal_dependencies_different_folders" + fileNameSuffix + ".txt";
+    }
+
+    /**
+     * The windows that were actually computed for these results - in window order, shortest first.
+     *
+     * <p>Empty when there is no commit history at all: in that case the analyzer never entered the
+     * co-change block, so every window's empty result is an artefact of the missing history rather
+     * than a statement about the code. Consumers must present only these windows.
+     */
+    public static List<TemporalDependenciesWindow> analyzedWindows(FilesHistoryAnalysisResults results,
+                                                                   int maxTemporalDependenciesDepthDays) {
+        List<TemporalDependenciesWindow> analyzed = new ArrayList<>();
+        if (!results.hasHistory()) {
+            return analyzed;
+        }
+        for (TemporalDependenciesWindow window : values()) {
+            if (window.isAnalyzed(maxTemporalDependenciesDepthDays)) {
+                analyzed.add(window);
+            }
+        }
+        return analyzed;
+    }
+}

--- a/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/analysis/results/TemporalDependenciesWindowTest.java
+++ b/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/analysis/results/TemporalDependenciesWindowTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2021 Željko Obrenović. All rights reserved.
+ */
+
+package nl.obren.sokrates.sourcecode.analysis.results;
+
+import nl.obren.sokrates.sourcecode.SourceFile;
+import nl.obren.sokrates.sourcecode.filehistory.FileModificationHistory;
+import nl.obren.sokrates.sourcecode.filehistory.FilePairChangedTogether;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The co-change windows a consumer may present.
+ *
+ * <p>Before this, three places decided independently which windows exist: the analyzer's four
+ * branches, the report generator's four tab conditions, and the data exporter (which knew about only
+ * two of the four). A window the analyzer skipped still got an exported file - a header line and
+ * nothing else, byte-identical to a repository whose files genuinely never change together.
+ */
+class TemporalDependenciesWindowTest {
+
+    @Test
+    void aWindowIsAnalyzedOnlyOnceTheConfiguredDepthReachesIt() {
+        assertEquals("[]", analyzedAt(0));
+        assertEquals("[]", analyzedAt(29));
+        assertEquals("[PAST_30_DAYS]", analyzedAt(30));
+        assertEquals("[PAST_30_DAYS]", analyzedAt(89));
+        assertEquals("[PAST_30_DAYS, PAST_90_DAYS]", analyzedAt(90));
+        assertEquals("[PAST_30_DAYS, PAST_90_DAYS]", analyzedAt(179));
+        assertEquals("[PAST_30_DAYS, PAST_90_DAYS, PAST_180_DAYS]", analyzedAt(180));
+        assertEquals("[PAST_30_DAYS, PAST_90_DAYS, PAST_180_DAYS, ALL_TIME]", analyzedAt(181));
+        // The default configured depth (AnalysisConfig.maxTemporalDependenciesDepthDays).
+        assertEquals("[PAST_30_DAYS, PAST_90_DAYS, PAST_180_DAYS, ALL_TIME]", analyzedAt(365));
+    }
+
+    @Test
+    void theAllTimeWindowNeedsMoreThanTheFixedOneHundredAndEightyDays() {
+        // The boundary that started this: at exactly 180 the all-time window would only repeat the
+        // 180-day one, so the analyzer skips it - and its result stays empty for that reason alone.
+        assertFalse(TemporalDependenciesWindow.ALL_TIME.isAnalyzed(180));
+        assertTrue(TemporalDependenciesWindow.ALL_TIME.isAnalyzed(181));
+        assertTrue(TemporalDependenciesWindow.PAST_180_DAYS.isAnalyzed(180));
+    }
+
+    @Test
+    void noWindowIsAnalyzedWithoutCommitHistoryHoweverDeepTheConfiguration() {
+        // The third way a window ends up empty, and the one the issue's two-state framing missed:
+        // the analyzer never enters the co-change block at all when no history was imported.
+        FilesHistoryAnalysisResults noHistory = new FilesHistoryAnalysisResults();
+
+        assertFalse(noHistory.hasHistory());
+        assertEquals(Collections.emptyList(), TemporalDependenciesWindow.analyzedWindows(noHistory, 365));
+        assertEquals(Collections.emptyList(), TemporalDependenciesWindow.analyzedWindows(noHistory, Integer.MAX_VALUE));
+    }
+
+    @Test
+    void eachWindowReadsItsOwnResultList() {
+        // Guards against a copy-paste in the accessor wiring - the kind that already exists in this
+        // model, where setFilePairsChangedTogether90Days names its parameter ...30Days.
+        FilesHistoryAnalysisResults results = new FilesHistoryAnalysisResults();
+        results.setFilePairsChangedTogether(pairs("all-time"));
+        results.setFilePairsChangedTogether30Days(pairs("30"));
+        results.setFilePairsChangedTogether90Days(pairs("90"));
+        results.setFilePairsChangedTogether180Days(pairs("180"));
+
+        assertEquals("30", firstPath(TemporalDependenciesWindow.PAST_30_DAYS, results));
+        assertEquals("90", firstPath(TemporalDependenciesWindow.PAST_90_DAYS, results));
+        assertEquals("180", firstPath(TemporalDependenciesWindow.PAST_180_DAYS, results));
+        assertEquals("all-time", firstPath(TemporalDependenciesWindow.ALL_TIME, results));
+    }
+
+    @Test
+    void everyWindowHasItsOwnPairOfDataFileNames() {
+        // The all-time window keeps the unsuffixed historical names; a collision here would make two
+        // windows overwrite each other's export.
+        assertEquals("[temporal_dependencies_30_days.txt, temporal_dependencies_90_days.txt, "
+                        + "temporal_dependencies_180_days.txt, temporal_dependencies.txt]",
+                names(TemporalDependenciesWindow::getDataFileName));
+        assertEquals("[temporal_dependencies_different_folders_30_days.txt, "
+                        + "temporal_dependencies_different_folders_90_days.txt, "
+                        + "temporal_dependencies_different_folders_180_days.txt, "
+                        + "temporal_dependencies_different_folders.txt]",
+                names(TemporalDependenciesWindow::getDifferentFoldersDataFileName));
+    }
+
+    private String analyzedAt(int maxTemporalDependenciesDepthDays) {
+        FilesHistoryAnalysisResults results = new FilesHistoryAnalysisResults();
+        results.setHistory(Collections.singletonList(new FileModificationHistory("a.java")));
+        return TemporalDependenciesWindow.analyzedWindows(results, maxTemporalDependenciesDepthDays).toString();
+    }
+
+    private String names(java.util.function.Function<TemporalDependenciesWindow, String> nameOf) {
+        return Arrays.stream(TemporalDependenciesWindow.values()).map(nameOf).collect(Collectors.toList()).toString();
+    }
+
+    private List<FilePairChangedTogether> pairs(String marker) {
+        return Collections.singletonList(
+                new FilePairChangedTogether(new SourceFile(new File(marker)), new SourceFile(new File("other"))));
+    }
+
+    private String firstPath(TemporalDependenciesWindow window, FilesHistoryAnalysisResults results) {
+        return window.getFilePairs(results).get(0).getSourceFile1().getFile().getPath();
+    }
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -145,7 +145,7 @@ Switches and risk thresholds for the analysis itself. Common keys:
 | `maxFileSizeBytes` / `maxLines` / `maxLineLength` | `1000000` / `10000` / `1000` | Skip files exceeding these. |
 | `locDuplicationThreshold` | `10000000` | Skip duplication when main LOC exceeds this. |
 | `minDuplicationBlockLoc` | `6` | Minimum duplicated block size (lines). |
-| `maxTemporalDependenciesDepthDays` | `365` | Days of git history used to compute temporal (changed-together) file dependencies. |
+| `maxTemporalDependenciesDepthDays` | `365` | Days of git history used to compute temporal (changed-together) file dependencies. Four windows are computed - 30, 90 and 180 days, plus one covering the configured depth - but only those the depth reaches: 90 needs `>= 90`, 180 needs `>= 180`, and the configured-depth window needs `> 180` (below that it would only repeat the 180-day one). Each computed window gets a tab in the temporal dependencies report and a pair of `data/text/temporal_dependencies*.txt` exports; a window that was not computed - including when there is no git history at all - gets neither, so a missing export means "not analysed" while a header-only one means "analysed, nothing found". |
 | `maxTopListSize` | `50` | Size of the "top N" sample lists (longest/most-changed files, longest/most-complex units, etc.). |
 | `fileSizeThresholds` | `{low:100, medium:200, high:500, veryHigh:1000}` | Risk bands for file size (LOC). |
 | `unitSizeThresholds` | `{low:10, medium:20, high:50, veryHigh:100}` | Risk bands for unit size. |

--- a/reports/src/main/java/nl/obren/sokrates/reports/dataexporters/DataExporter.java
+++ b/reports/src/main/java/nl/obren/sokrates/reports/dataexporters/DataExporter.java
@@ -28,6 +28,8 @@ import nl.obren.sokrates.sourcecode.SourceFileWithSearchData;
 import nl.obren.sokrates.sourcecode.analysis.results.AspectAnalysisResults;
 import nl.obren.sokrates.sourcecode.analysis.results.CodeAnalysisResults;
 import nl.obren.sokrates.sourcecode.analysis.results.DuplicationAnalysisResults;
+import nl.obren.sokrates.sourcecode.analysis.results.FilesHistoryAnalysisResults;
+import nl.obren.sokrates.sourcecode.analysis.results.TemporalDependenciesWindow;
 import nl.obren.sokrates.sourcecode.analysis.results.UnitsAnalysisResults;
 import nl.obren.sokrates.sourcecode.aspects.NamedSourceCodeAspect;
 import nl.obren.sokrates.sourcecode.contributors.Contributor;
@@ -317,20 +319,37 @@ public class DataExporter {
         });
     }
 
+    // Exports every co-change window the analyzer computed, and only those: a window that was not
+    // analyzed (because the configured depth does not reach it, or because there is no commit
+    // history at all) gets no file, so its absence cannot be misread as "analyzed, nothing found" -
+    // which a header-only file is indistinguishable from.
     private void saveTemporalDependencies(CodeAnalysisResults analysisResults) {
-        List<FilePairChangedTogether> filePairsChangedTogether = analysisResults.getFilesHistoryAnalysisResults().getFilePairsChangedTogether();
-        exportFilesChangedTogether(filePairsChangedTogether,
-                "temporal_dependencies.txt");
-        exportFilesChangedTogether(analysisResults.getFilesHistoryAnalysisResults().getFilePairsChangedTogetherInDifferentFolders(filePairsChangedTogether),
-                "temporal_dependencies_different_folders.txt");
-        List<FilePairChangedTogether> filePairsChangedTogether30Days = analysisResults.getFilesHistoryAnalysisResults().getFilePairsChangedTogether30Days();
-        exportFilesChangedTogether(filePairsChangedTogether30Days,
-                "temporal_dependencies_30_days.txt");
-        exportFilesChangedTogether(analysisResults.getFilesHistoryAnalysisResults().getFilePairsChangedTogetherInDifferentFolders(filePairsChangedTogether30Days),
-                "temporal_dependencies_different_folders_30_days.txt");
+        saveTemporalDependencies(analysisResults, textDataFolder);
     }
 
-    private void exportFilesChangedTogether(List<FilePairChangedTogether> filePairsChangedTogether, String fileName) {
+    // Package-private so the set of exported windows can be asserted without a full analysis run.
+    void saveTemporalDependencies(CodeAnalysisResults analysisResults, File targetFolder) {
+        FilesHistoryAnalysisResults historyResults = analysisResults.getFilesHistoryAnalysisResults();
+        int maxDays = analysisResults.getCodeConfiguration().getAnalysis().getMaxTemporalDependenciesDepthDays();
+        List<TemporalDependenciesWindow> analyzed = TemporalDependenciesWindow.analyzedWindows(historyResults, maxDays);
+
+        Arrays.stream(TemporalDependenciesWindow.values())
+                .filter(window -> !analyzed.contains(window))
+                .forEach(window -> LOG.info("Not exporting " + window.getDataFileName()
+                        + ": co-change window not analyzed ("
+                        + (historyResults.hasHistory()
+                        ? "maxTemporalDependenciesDepthDays=" + maxDays
+                        : "no commit history") + ")"));
+
+        analyzed.forEach(window -> {
+            List<FilePairChangedTogether> filePairs = window.getFilePairs(historyResults);
+            exportFilesChangedTogether(filePairs, window.getDataFileName(), targetFolder);
+            exportFilesChangedTogether(historyResults.getFilePairsChangedTogetherInDifferentFolders(filePairs),
+                    window.getDifferentFoldersDataFileName(), targetFolder);
+        });
+    }
+
+    private void exportFilesChangedTogether(List<FilePairChangedTogether> filePairsChangedTogether, String fileName, File targetFolder) {
         StringBuilder content = new StringBuilder();
         content.append("file 1\tfile 2\t# same commits\t# commits file 1\t# commits file 2\n");
         if (filePairsChangedTogether.size() > 0) {
@@ -348,7 +367,7 @@ public class DataExporter {
             });
         }
         try {
-            FileUtils.write(new File(textDataFolder, fileName), content.toString(), UTF_8);
+            FileUtils.write(new File(targetFolder, fileName), content.toString(), UTF_8);
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/reports/src/main/java/nl/obren/sokrates/reports/generators/statichtml/FileTemporalDependenciesReportGenerator.java
+++ b/reports/src/main/java/nl/obren/sokrates/reports/generators/statichtml/FileTemporalDependenciesReportGenerator.java
@@ -9,6 +9,8 @@ import nl.obren.sokrates.common.utils.ProcessingStopwatch;
 import nl.obren.sokrates.reports.core.RichTextReport;
 import nl.obren.sokrates.reports.utils.GraphvizDependencyRenderer;
 import nl.obren.sokrates.sourcecode.analysis.results.CodeAnalysisResults;
+import nl.obren.sokrates.sourcecode.analysis.results.FilesHistoryAnalysisResults;
+import nl.obren.sokrates.sourcecode.analysis.results.TemporalDependenciesWindow;
 import nl.obren.sokrates.sourcecode.dependencies.ComponentDependency;
 import nl.obren.sokrates.sourcecode.filehistory.FilePairChangedTogether;
 import nl.obren.sokrates.sourcecode.filehistory.TemporalDependenciesHelper;
@@ -37,47 +39,58 @@ public class FileTemporalDependenciesReportGenerator {
                 "at the same time (i.e. they are a part of the same commit).", "margin-top: 12px; color: grey; font-size: 94%");
 
         int maxTemporalDependenciesDepthDays = codeAnalysisResults.getCodeConfiguration().getAnalysis().getMaxTemporalDependenciesDepthDays();
+        FilesHistoryAnalysisResults historyResults = codeAnalysisResults.getFilesHistoryAnalysisResults();
+
+        // Only the windows the analyzer actually computed get a tab; showing a tab for a window that
+        // was never analyzed would present "no dependencies" as a finding about the code.
+        List<TemporalDependenciesWindow> windows =
+                TemporalDependenciesWindow.analyzedWindows(historyResults, maxTemporalDependenciesDepthDays);
+
+        if (windows.isEmpty()) {
+            report.addParagraph(historyResults.hasHistory()
+                    ? "No temporal dependencies were analyzed: the configured analysis depth ("
+                    + maxTemporalDependenciesDepthDays + " days) is shorter than the shortest window ("
+                    + TemporalDependenciesWindow.PAST_30_DAYS.getDepthDays() + " days)."
+                    : "No temporal dependencies were analyzed: no commit history is available.");
+            return;
+        }
 
         report.startTabGroup();
-        report.addTab("30_days", "Past 30 Days", true);
-        if (maxTemporalDependenciesDepthDays >= 90) {
-            report.addTab("90_days", "Past 3 Months", false);
-        }
-        if (maxTemporalDependenciesDepthDays >= 180) {
-            report.addTab("180_days", "Past 6 Months", false);
-        }
-        if (maxTemporalDependenciesDepthDays > 180) {
-            report.addTab("all_time", "Past " + maxTemporalDependenciesDepthDays + " Days", false);
+        for (int i = 0; i < windows.size(); i++) {
+            TemporalDependenciesWindow window = windows.get(i);
+            report.addTab(window.getId(), tabLabel(window, maxTemporalDependenciesDepthDays), i == 0);
         }
         report.endTabGroup();
 
-        List<FilePairChangedTogether> filePairsChangedTogether = codeAnalysisResults.getFilesHistoryAnalysisResults().getFilePairsChangedTogether();
-        List<FilePairChangedTogether> filePairsChangedTogether30Days = codeAnalysisResults.getFilesHistoryAnalysisResults().getFilePairsChangedTogether30Days();
-        List<FilePairChangedTogether> filePairsChangedTogether90Days = codeAnalysisResults.getFilesHistoryAnalysisResults().getFilePairsChangedTogether90Days();
-        List<FilePairChangedTogether> filePairsChangedTogether180Days = codeAnalysisResults.getFilesHistoryAnalysisResults().getFilePairsChangedTogether180Days();
-
-        addTabContentSection(report, "30_days", filePairsChangedTogether30Days, true);
-        if (maxTemporalDependenciesDepthDays >= 90) {
-            addTabContentSection(report, "90_days", filePairsChangedTogether90Days, false);
-        }
-        if (maxTemporalDependenciesDepthDays >= 180) {
-            addTabContentSection(report, "180_days", filePairsChangedTogether180Days, false);
-        }
-        if (maxTemporalDependenciesDepthDays > 180) {
-            addTabContentSection(report, "all_time", filePairsChangedTogether, false);
+        for (int i = 0; i < windows.size(); i++) {
+            TemporalDependenciesWindow window = windows.get(i);
+            addTabContentSection(report, window, window.getFilePairs(historyResults), i == 0);
         }
     }
 
-    private void addTabContentSection(RichTextReport report, String id, List<FilePairChangedTogether> filePairs, boolean active) {
-        report.startTabContentSection(id, active);
-        addDependenciesSection(report, filePairs, id);
-        addFileChangedTogetherList(report, filePairs);
-        addFileChangedTogetherInDifferentFoldersList(report, filePairs);
+    private String tabLabel(TemporalDependenciesWindow window, int maxTemporalDependenciesDepthDays) {
+        switch (window) {
+            case PAST_30_DAYS:
+                return "Past 30 Days";
+            case PAST_90_DAYS:
+                return "Past 3 Months";
+            case PAST_180_DAYS:
+                return "Past 6 Months";
+            default:
+                return "Past " + maxTemporalDependenciesDepthDays + " Days";
+        }
+    }
+
+    private void addTabContentSection(RichTextReport report, TemporalDependenciesWindow window, List<FilePairChangedTogether> filePairs, boolean active) {
+        report.startTabContentSection(window.getId(), active);
+        addDependenciesSection(report, filePairs, window.getId());
+        addFileChangedTogetherList(report, window, filePairs);
+        addFileChangedTogetherInDifferentFoldersList(report, window, filePairs);
         report.endTabContentSection();
 
     }
 
-    private void addFileChangedTogetherList(RichTextReport report, List<FilePairChangedTogether> filePairs) {
+    private void addFileChangedTogetherList(RichTextReport report, TemporalDependenciesWindow window, List<FilePairChangedTogether> filePairs) {
         if (filePairs.size() == 0) {
             report.addParagraph("No file pairs changed together.");
             return;
@@ -88,12 +101,13 @@ public class FileTemporalDependenciesReportGenerator {
         }
         report.addLineBreak();
         report.startSubSection("Files Most Frequently Changed Together (Top " + filePairs.size() + ")", "");
-        report.addParagraph("<a href='#' onclick=\"return downloadDataFile('text/temporal_dependencies.txt')\" target='_blank'>data...</a>");
+        // The data file must be this tab's window, not the all-time one.
+        report.addParagraph(dataFileLink("text/" + window.getDataFileName()));
         addTable(report, filePairs);
         report.endSection();
     }
 
-    private void addFileChangedTogetherInDifferentFoldersList(RichTextReport report, List<FilePairChangedTogether> filePairsChangedTogether) {
+    private void addFileChangedTogetherInDifferentFoldersList(RichTextReport report, TemporalDependenciesWindow window, List<FilePairChangedTogether> filePairsChangedTogether) {
         List<FilePairChangedTogether> filePairs = codeAnalysisResults.getFilesHistoryAnalysisResults().getFilePairsChangedTogetherInDifferentFolders(filePairsChangedTogether);
         if (filePairs.size() == 0) {
             return;
@@ -105,9 +119,13 @@ public class FileTemporalDependenciesReportGenerator {
         // Subsection (not top-level section) to match addFileChangedTogetherList, since this renders
         // alongside it inside a tab content section.
         report.startSubSection("Files from Different Folders Most Frequently Changed Together (Top " + filePairs.size() + ")", "");
-        report.addParagraph("<a href='#' onclick=\"return downloadDataFile('text/temporal_dependencies_different_folders.txt')\" target='_blank'>data...</a>");
+        report.addParagraph(dataFileLink("text/" + window.getDifferentFoldersDataFileName()));
         addTable(report, filePairs);
         report.endSection();
+    }
+
+    private String dataFileLink(String entry) {
+        return "<a href='#' onclick=\"return downloadDataFile('" + entry + "')\" target='_blank'>data...</a>";
     }
 
     private void addTable(RichTextReport report, List<FilePairChangedTogether> filePairs) {

--- a/reports/src/test/java/nl/obren/sokrates/reports/dataexporters/DataExporterTemporalDependenciesTest.java
+++ b/reports/src/test/java/nl/obren/sokrates/reports/dataexporters/DataExporterTemporalDependenciesTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2021 Željko Obrenović. All rights reserved.
+ */
+
+package nl.obren.sokrates.reports.dataexporters;
+
+import nl.obren.sokrates.sourcecode.SourceFile;
+import nl.obren.sokrates.sourcecode.analysis.results.CodeAnalysisResults;
+import nl.obren.sokrates.sourcecode.analysis.results.FilesHistoryAnalysisResults;
+import nl.obren.sokrates.sourcecode.core.CodeConfiguration;
+import nl.obren.sokrates.sourcecode.filehistory.FileModificationHistory;
+import nl.obren.sokrates.sourcecode.filehistory.FilePairChangedTogether;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * What data/text/ says about the co-change windows.
+ *
+ * <p>Two of the four analyzed windows were exported, and the two unexported ones were the deepest -
+ * so a repository configured for 180 days received 30 days of data. Worse, an unanalyzed window
+ * still got its file, holding the column header and nothing else: byte-identical to a repository
+ * whose files genuinely never change together. Absence now carries that distinction.
+ */
+class DataExporterTemporalDependenciesTest {
+
+    private static final String HEADER = "file 1\tfile 2\t# same commits\t# commits file 1\t# commits file 2\n";
+
+    @Test
+    void everyAnalyzedWindowIsExported(@TempDir File folder) {
+        // Previously only the first two of these were written, at the default depth of 365 days.
+        export(365, folder);
+
+        assertEquals(Arrays.asList(
+                "temporal_dependencies.txt",
+                "temporal_dependencies_180_days.txt",
+                "temporal_dependencies_30_days.txt",
+                "temporal_dependencies_90_days.txt",
+                "temporal_dependencies_different_folders.txt",
+                "temporal_dependencies_different_folders_180_days.txt",
+                "temporal_dependencies_different_folders_30_days.txt",
+                "temporal_dependencies_different_folders_90_days.txt"),
+                fileNames(folder));
+    }
+
+    @Test
+    void aWindowTheAnalyzerSkippedIsNotWrittenAtAll(@TempDir File folder) {
+        // At exactly 180 days the all-time analysis does not run. Writing its empty result would
+        // claim, in the same bytes an empty repository produces, that nothing changes together.
+        export(180, folder);
+
+        assertEquals(Arrays.asList(
+                "temporal_dependencies_180_days.txt",
+                "temporal_dependencies_30_days.txt",
+                "temporal_dependencies_90_days.txt",
+                "temporal_dependencies_different_folders_180_days.txt",
+                "temporal_dependencies_different_folders_30_days.txt",
+                "temporal_dependencies_different_folders_90_days.txt"),
+                fileNames(folder));
+    }
+
+    @Test
+    void withoutCommitHistoryNoWindowIsExported(@TempDir File folder) {
+        CodeAnalysisResults results = resultsWithPairsInEveryWindow(365);
+        results.getFilesHistoryAnalysisResults().setHistory(new ArrayList<>());
+
+        new DataExporter(null).saveTemporalDependencies(results, folder);
+
+        assertEquals(Collections.emptyList(), fileNames(folder));
+    }
+
+    @Test
+    void anAnalyzedWindowThatFoundNothingStillGetsItsHeaderOnlyFile(@TempDir File folder) throws IOException {
+        // The other half of the distinction: analyzed-and-empty remains a present, empty file.
+        CodeAnalysisResults results = resultsWithPairsInEveryWindow(365);
+        results.getFilesHistoryAnalysisResults().setFilePairsChangedTogether90Days(new ArrayList<>());
+
+        new DataExporter(null).saveTemporalDependencies(results, folder);
+
+        assertEquals(HEADER, read(folder, "temporal_dependencies_90_days.txt"));
+        assertEquals(HEADER + "a/one.java\tb/two.java\t1\t1\t1\n", read(folder, "temporal_dependencies_30_days.txt"));
+    }
+
+    private void export(int maxTemporalDependenciesDepthDays, File folder) {
+        new DataExporter(null).saveTemporalDependencies(resultsWithPairsInEveryWindow(maxTemporalDependenciesDepthDays), folder);
+    }
+
+    private CodeAnalysisResults resultsWithPairsInEveryWindow(int maxTemporalDependenciesDepthDays) {
+        CodeAnalysisResults results = new CodeAnalysisResults();
+        results.setCodeConfiguration(CodeConfiguration.getDefaultConfiguration());
+        results.getCodeConfiguration().getAnalysis().setMaxTemporalDependenciesDepthDays(maxTemporalDependenciesDepthDays);
+
+        FilesHistoryAnalysisResults history = results.getFilesHistoryAnalysisResults();
+        history.setHistory(Collections.singletonList(new FileModificationHistory("a/one.java")));
+        history.setFilePairsChangedTogether30Days(pair());
+        history.setFilePairsChangedTogether90Days(pair());
+        history.setFilePairsChangedTogether180Days(pair());
+        history.setFilePairsChangedTogether(pair());
+        return results;
+    }
+
+    private List<FilePairChangedTogether> pair() {
+        SourceFile file1 = new SourceFile(new File("a/one.java"));
+        file1.setRelativePath("a/one.java");
+        SourceFile file2 = new SourceFile(new File("b/two.java"));
+        file2.setRelativePath("b/two.java");
+        FilePairChangedTogether pair = new FilePairChangedTogether(file1, file2);
+        pair.setCommits(new ArrayList<>(Collections.singletonList("commit-1")));
+        pair.setCommitsCountFile1(1);
+        pair.setCommitsCountFile2(1);
+        return new ArrayList<>(Collections.singletonList(pair));
+    }
+
+    private List<String> fileNames(File folder) {
+        String[] names = folder.list();
+        List<String> sorted = names == null ? new ArrayList<>() : new ArrayList<>(Arrays.asList(names));
+        Collections.sort(sorted);
+        return sorted;
+    }
+
+    private String read(File folder, String name) throws IOException {
+        return FileUtils.readFileToString(new File(folder, name), StandardCharsets.UTF_8);
+    }
+}

--- a/reports/src/test/java/nl/obren/sokrates/reports/generators/statichtml/FileTemporalDependenciesReportGeneratorTest.java
+++ b/reports/src/test/java/nl/obren/sokrates/reports/generators/statichtml/FileTemporalDependenciesReportGeneratorTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2021 Željko Obrenović. All rights reserved.
+ */
+
+package nl.obren.sokrates.reports.generators.statichtml;
+
+import nl.obren.sokrates.reports.core.RichTextFragment;
+import nl.obren.sokrates.reports.core.RichTextReport;
+import nl.obren.sokrates.sourcecode.SourceFile;
+import nl.obren.sokrates.sourcecode.analysis.results.CodeAnalysisResults;
+import nl.obren.sokrates.sourcecode.analysis.results.FilesHistoryAnalysisResults;
+import nl.obren.sokrates.sourcecode.core.CodeConfiguration;
+import nl.obren.sokrates.sourcecode.filehistory.FileModificationHistory;
+import nl.obren.sokrates.sourcecode.filehistory.FilePairChangedTogether;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The "data..." links under each co-change tab.
+ *
+ * <p>Every tab used to link to text/temporal_dependencies.txt and its different-folders sibling -
+ * the all-time files - because the tab was never consulted when building the link. On a default
+ * configuration that silently served all-time data from the 30-day tab, which is the one that opens
+ * first; below 181 days it served a file the analyzer had left empty.
+ */
+class FileTemporalDependenciesReportGeneratorTest {
+
+    private static final Pattern DATA_FILE = Pattern.compile("downloadDataFile\\('text/(temporal_dependencies[^']*)'\\)");
+
+    @Test
+    void eachTabLinksToTheDataFileOfItsOwnWindow(@TempDir File reportsFolder) {
+        RichTextReport report = renderWith(365, reportsFolder);
+
+        // In tab order, each tab contributing its own pair of files.
+        assertEquals(Arrays.asList(
+                "temporal_dependencies_30_days.txt", "temporal_dependencies_different_folders_30_days.txt",
+                "temporal_dependencies_90_days.txt", "temporal_dependencies_different_folders_90_days.txt",
+                "temporal_dependencies_180_days.txt", "temporal_dependencies_different_folders_180_days.txt",
+                "temporal_dependencies.txt", "temporal_dependencies_different_folders.txt"),
+                linkedDataFiles(report));
+    }
+
+    @Test
+    void aWindowTheAnalyzerSkippedGetsNoTabAndNoLink(@TempDir File reportsFolder) {
+        // At 180 days the all-time analysis does not run. Rendering its (empty) result as a tab would
+        // report "no file pairs changed together" as a finding, and link a file that is not written.
+        RichTextReport report = renderWith(180, reportsFolder);
+
+        String html = htmlOf(report);
+        assertTrue(html.contains("temporal_dependencies_180_days.txt"), html);
+        assertEquals(Collections.emptyList(), linkedDataFiles(report).stream()
+                .filter(name -> name.equals("temporal_dependencies.txt")
+                        || name.equals("temporal_dependencies_different_folders.txt"))
+                .collect(Collectors.toList()));
+    }
+
+    @Test
+    void withoutCommitHistoryNothingIsPresentedAsAnalyzed(@TempDir File reportsFolder) {
+        CodeAnalysisResults results = resultsWithPairsInEveryWindow();
+        results.getFilesHistoryAnalysisResults().setHistory(new ArrayList<>());
+
+        RichTextReport report = new RichTextReport("", "");
+        new FileTemporalDependenciesReportGenerator(results).addTemporalDependenciesToReport(reportsFolder, report);
+
+        assertEquals(Collections.emptyList(), linkedDataFiles(report));
+        assertTrue(htmlOf(report).contains("no commit history is available"), htmlOf(report));
+    }
+
+    @Test
+    void aDepthShorterThanTheShortestWindowSaysSoRatherThanShowingAnEmptyTab(@TempDir File reportsFolder) {
+        RichTextReport report = renderWith(10, reportsFolder);
+
+        assertEquals(Collections.emptyList(), linkedDataFiles(report));
+        assertTrue(htmlOf(report).contains("shorter than the shortest window"), htmlOf(report));
+    }
+
+    private RichTextReport renderWith(int maxTemporalDependenciesDepthDays, File reportsFolder) {
+        CodeAnalysisResults results = resultsWithPairsInEveryWindow();
+        results.getCodeConfiguration().getAnalysis().setMaxTemporalDependenciesDepthDays(maxTemporalDependenciesDepthDays);
+
+        RichTextReport report = new RichTextReport("", "");
+        new FileTemporalDependenciesReportGenerator(results).addTemporalDependenciesToReport(reportsFolder, report);
+        return report;
+    }
+
+    /** Every window holds one pair, in two different folders so both link sites render. */
+    private CodeAnalysisResults resultsWithPairsInEveryWindow() {
+        CodeAnalysisResults results = new CodeAnalysisResults();
+        results.setCodeConfiguration(CodeConfiguration.getDefaultConfiguration());
+
+        FilesHistoryAnalysisResults history = results.getFilesHistoryAnalysisResults();
+        history.setHistory(Collections.singletonList(new FileModificationHistory("a/one.java")));
+        history.setFilePairsChangedTogether30Days(pair());
+        history.setFilePairsChangedTogether90Days(pair());
+        history.setFilePairsChangedTogether180Days(pair());
+        history.setFilePairsChangedTogether(pair());
+        return results;
+    }
+
+    private List<FilePairChangedTogether> pair() {
+        SourceFile file1 = new SourceFile(new File("a/one.java"));
+        file1.setRelativePath("a/one.java");
+        SourceFile file2 = new SourceFile(new File("b/two.java"));
+        file2.setRelativePath("b/two.java");
+        FilePairChangedTogether pair = new FilePairChangedTogether(file1, file2);
+        pair.setCommits(new ArrayList<>(Collections.singletonList("commit-1")));
+        pair.setCommitsCountFile1(1);
+        pair.setCommitsCountFile2(1);
+        return new ArrayList<>(Collections.singletonList(pair));
+    }
+
+    private List<String> linkedDataFiles(RichTextReport report) {
+        List<String> names = new ArrayList<>();
+        Matcher matcher = DATA_FILE.matcher(htmlOf(report));
+        while (matcher.find()) {
+            names.add(matcher.group(1));
+        }
+        return names;
+    }
+
+    private String htmlOf(RichTextReport report) {
+        return report.getRichTextFragments().stream()
+                .map(RichTextFragment::getFragment)
+                .collect(Collectors.joining("\n"));
+    }
+}


### PR DESCRIPTION
On a default config, open a repository report → **Temporal Dependencies** → click **data...** under the 30-day tab. You get all-time data. Every tab does — the link is hardcoded to `text/temporal_dependencies.txt` and never consults the tab.

Set `maxTemporalDependenciesDepthDays` to 180 and that same link opens a 63-byte file containing only a column header, while the table above it is full of rows.

Separately, on **every** default run the 90- and 180-day co-change results are computed and never written to `data/` — on this repository, ~2.3 MB of analysis paid for and dropped.

## Cause

`FileHistoryAnalyzer` computes four windows, gated on the configured depth: 30 (`>=30`), 90 (`>=90`), 180 (`>=180`), all-time (`>180`). Three places then decided independently what to do with them and disagreed: the exporter knew about only two of the four; the report generator gated its *tabs* correctly but built every tab's link from the all-time names; and a window the analyser **skipped** still got its file written — a column header and nothing else, byte-for-byte what a repository whose files genuinely never change together produces.

That last one is the sharp edge: a check that did not execute produced output identical to one that executed and passed. Nothing distinguished "never analysed", "no git history at all", and "analysed, found nothing", and the skip was not logged while every branch that ran was.

## Change

`TemporalDependenciesWindow` holds the one predicate all three places now consult.

- All four windows are exported, each under its own pair of names.
- A window that was not analysed gets **no file** — absence means "not analysed", a header-only file still means "analysed, found nothing".
- Each tab links to its own window's files; an unanalysed window gets no tab rather than an empty one.
- The analyser logs which windows it will compute.

## Verification

Run end-to-end against a real fixture (full clone of this repo, 905 commits, 7,674 file changes) at three depths. At the default, eight files carry real data where four existed. At 180, `temporal_dependencies.txt` is absent rather than a stub. With no history, nothing is exported and each window logs why.

13 new tests; 10 mutations applied, 10 killed, including faithful reintroductions of both original bugs.

## Two things for you to decide

**1. Is the shared enum welcome?** The three copies of the predicate are what let the exporter drift to knowing about two of four windows, so consolidating them is the fix rather than a tidy-up — but it adds a type to `codeanalyzer` and respells `FileHistoryAnalyzer`'s four conditions (predicates identical, verified against `master`). If you'd rather the analyser stayed untouched and the predicate were duplicated in the other two, that's a small edit and I'll make it.

**2. Removing a file that always existed is a contract change.** `temporal_dependencies.txt` and its `_different_folders` sibling will now be absent for any config with depth `<= 180`, and for repositories with no git history.

Nothing in this repository reads them (grepped, including `cli/` and `codeexplorer/`; the landscape reads only `text/aspect_*.txt` and `text/mainFilesWithHistory.txt`), and links are only emitted for windows that are exported, so no dangling links. I also checked the one downstream consumer I have visibility into — a commercial tool that ingests Sokrates output — and it reads only `analysisResults.json`, `config.json`, `contributors.json`, `units.json` and `text/metrics.txt`, treating `data.zip` as opaque otherwise. Notably its repositories are configured at exactly 180, so they are among those receiving the header-only stub today.

That is two data points, not a survey. If you know of tooling that opens those paths unconditionally, writing a machine-readable "not analysed" marker instead of omitting the file is the obvious alternative, and I will switch to it.

## Not in this PR

`LogicalComponentsReportGenerator.addTemporalDependenciesSection` reads the 180-day list unconditionally under a "past 180 days" heading, so below a depth of 180 it renders an empty graph for a window that was never measured — same failure mode, different report. Left out to keep this to one concern; happy to follow up.
