### PR TITLE
Read a landscape's scope file lists under the configured aspect names

### DIFF
--- a/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/landscape/analysis/LandscapeAnalyzer.java
+++ b/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/landscape/analysis/LandscapeAnalyzer.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import nl.obren.sokrates.common.io.JsonGenerator;
 import nl.obren.sokrates.common.io.JsonMapper;
 import nl.obren.sokrates.sourcecode.analysis.results.CodeAnalysisResults;
+import nl.obren.sokrates.sourcecode.aspects.NamedSourceCodeAspect;
 import nl.obren.sokrates.sourcecode.contributors.Contributor;
 import nl.obren.sokrates.sourcecode.core.CodeConfiguration;
 import nl.obren.sokrates.sourcecode.dependencies.ComponentDependency;
@@ -117,7 +118,7 @@ public class LandscapeAnalyzer {
                     String repositoryName = repositoryAnalysisResults.getMetadata().getName();
                     if (!landscapeConfiguration.isIncludeOnlyOneRepositoryWithSameName() || !repositoryNames.contains(repositoryName)) {
                         repositoryNames.add(repositoryName);
-                        List<FileExport> files = this.getRepositoryFiles(repositoryName, link);
+                        List<FileExport> files = this.getRepositoryFiles(repositoryName, link, repositoryAnalysisResults.getCodeConfiguration());
                         landscapeAnalysisResults.getRepositoryAnalysisResults().add(new RepositoryAnalysisResults(link, repositoryAnalysisResults, files));
                         repositoryAnalysisResults.getContributorsAnalysisResults().getContributors().forEach(contributor -> {
                             contributor.getCommitDates().forEach(commitDate -> {
@@ -343,20 +344,62 @@ public class LandscapeAnalyzer {
         return null;
     }
 
-    private List<FileExport> getRepositoryFiles(String repositoryName, SokratesRepositoryLink sokratesRepositoryLink) {
+    /**
+     * The files of a repository, read from the five scope file lists it was exported with.
+     *
+     * <p>The names of those lists were five literals here - "aspect_main.txt" and so on - which is
+     * what the <em>default</em> aspect names produce. The writer derives each name from the aspect's
+     * configured name, so a repository that renamed a scope aspect in its config.json had this
+     * reading an entry nothing had written; a missing entry reads as null, so that scope contributed
+     * no files at all - no exception, nothing in the log, just a smaller repository in the landscape.
+     * The names now come from the repository's own configuration.
+     *
+     * <p>The scope a file belongs to is passed separately rather than recovered from the file name,
+     * so it stays "main" even when the aspect is called something else. These are the same scope
+     * keys the per-repository files explorer exports.
+     */
+    private List<FileExport> getRepositoryFiles(String repositoryName, SokratesRepositoryLink sokratesRepositoryLink,
+                                                CodeConfiguration configuration) {
+        // The default names are the fallback, per scope. The whole configuration is null for a
+        // repository exported without a readable config.json, and a single aspect is null when a
+        // config.json sets that scope to null - of the five setters only setMain rejects one. The
+        // default name is then the best remaining guess, and is what such a repository was read
+        // under before the names followed the configuration.
+        CodeConfiguration defaults = new CodeConfiguration();
+        CodeConfiguration scopes = configuration != null ? configuration : defaults;
+
         List<FileExport> files = new ArrayList<>();
 
-        files.addAll(getRepositoryFilesByScope(repositoryName, sokratesRepositoryLink, "aspect_main.txt"));
-        files.addAll(getRepositoryFilesByScope(repositoryName, sokratesRepositoryLink, "aspect_test.txt"));
-        files.addAll(getRepositoryFilesByScope(repositoryName, sokratesRepositoryLink, "aspect_generated.txt"));
-        files.addAll(getRepositoryFilesByScope(repositoryName, sokratesRepositoryLink, "aspect_build_and_deployment.txt"));
-        files.addAll(getRepositoryFilesByScope(repositoryName, sokratesRepositoryLink, "aspect_other.txt"));
-        files.addAll(getRepositoryFilesByScope(repositoryName, sokratesRepositoryLink, "excluded_files_ignored_extensions.txt"));
-        files.addAll(getRepositoryFilesByScope(repositoryName, sokratesRepositoryLink, "excluded_files_ignored_rules.txt"));
+        addScopeFiles(files, repositoryName, sokratesRepositoryLink, orDefault(scopes.getMain(), defaults.getMain()), "main");
+        addScopeFiles(files, repositoryName, sokratesRepositoryLink, orDefault(scopes.getTest(), defaults.getTest()), "test");
+        addScopeFiles(files, repositoryName, sokratesRepositoryLink, orDefault(scopes.getGenerated(), defaults.getGenerated()), "generated");
+        addScopeFiles(files, repositoryName, sokratesRepositoryLink, orDefault(scopes.getBuildAndDeployment(), defaults.getBuildAndDeployment()), "build");
+        addScopeFiles(files, repositoryName, sokratesRepositoryLink, orDefault(scopes.getOther(), defaults.getOther()), "other");
+
+        files.addAll(getRepositoryFilesByScope(repositoryName, sokratesRepositoryLink, "excluded_files_ignored_extensions.txt", "other"));
+        files.addAll(getRepositoryFilesByScope(repositoryName, sokratesRepositoryLink, "excluded_files_ignored_rules.txt", "other"));
 
         enrichFilesWithCommitHistory(files, sokratesRepositoryLink);
 
         return files;
+    }
+
+    private static NamedSourceCodeAspect orDefault(NamedSourceCodeAspect aspect, NamedSourceCodeAspect defaultAspect) {
+        return aspect != null ? aspect : defaultAspect;
+    }
+
+    private void addScopeFiles(List<FileExport> files, String repositoryName, SokratesRepositoryLink sokratesRepositoryLink,
+                               NamedSourceCodeAspect aspect, String scope) {
+        files.addAll(getRepositoryFilesByScope(repositoryName, sokratesRepositoryLink, scopeFileListName(aspect), scope));
+    }
+
+    /**
+     * The file list a scope aspect was exported to: "aspect_" + the aspect's file-system-friendly
+     * name + ".txt". This is the derivation the writer uses - DataExportUtils.getAspectFileListFileName,
+     * in the reports module, which this module does not depend on.
+     */
+    static String scopeFileListName(NamedSourceCodeAspect aspect) {
+        return "aspect_" + aspect.getFileSystemFriendlyName("") + ".txt";
     }
 
     /**
@@ -448,7 +491,7 @@ public class LandscapeAnalyzer {
         }
     }
 
-    private List<FileExport> getRepositoryFilesByScope(String repositoryName, SokratesRepositoryLink sokratesRepositoryLink, String scopeFile) {
+    private List<FileExport> getRepositoryFilesByScope(String repositoryName, SokratesRepositoryLink sokratesRepositoryLink, String scopeFile, String scope) {
         try {
             File dataFolder = getRepositoryAnalysisFile(sokratesRepositoryLink).getParentFile();
             String content = readDataEntry(dataFolder, "text/" + scopeFile);
@@ -459,7 +502,7 @@ public class LandscapeAnalyzer {
                         .forEach(file -> {
                             String data[] = file.split("\t");
                             if (data.length > 1 && NumberUtils.isDigits(data[1])) {
-                                fileExports.add(new FileExport(repositoryName, data[0], scopeFile, Integer.parseInt(data[1])));
+                                fileExports.add(new FileExport(repositoryName, data[0], scope, Integer.parseInt(data[1])));
                             }
                         });
 

--- a/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/landscape/analysis/LandscapeAnalyzerScopeFileListsTest.java
+++ b/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/landscape/analysis/LandscapeAnalyzerScopeFileListsTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2021 Željko Obrenović. All rights reserved.
+ */
+
+package nl.obren.sokrates.sourcecode.landscape.analysis;
+
+import nl.obren.sokrates.common.io.JsonGenerator;
+import nl.obren.sokrates.sourcecode.aspects.NamedSourceCodeAspect;
+import nl.obren.sokrates.sourcecode.core.CodeConfiguration;
+import org.apache.commons.io.FileUtils;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * A repository's scope file lists are read under the names its own aspects produce, not under five
+ * literals.
+ *
+ * <p>The literals and the default names agree, which is why the difference stayed invisible: it shows
+ * only once somebody renames a scope aspect in config.json, which the configuration model allows. A
+ * missing entry reads as null here, so the scope contributed no files and the landscape reported a
+ * smaller repository - without an exception or a line in the log.
+ */
+public class LandscapeAnalyzerScopeFileListsTest {
+
+    /** One file per scope, main with two, in the order the analyzer reads the scopes. */
+    private static final String ALL_SCOPES = "[main/src/A.java, main/src/B.java, test/src/ATest.java, "
+            + "generated/gen/G.java, build/build/deploy.sh, other/docs/notes.md]";
+
+    @Test
+    public void aRenamedScopeAspectStillContributesItsFiles() throws Exception {
+        // The guard. Before the fix this repository contributed 0 main files instead of 2.
+        CodeConfiguration configuration = CodeConfiguration.getDefaultConfiguration();
+        configuration.getMain().setName("production code");
+        File landscapeConfigFile = landscapeOverRepository(configuration);
+
+        List<FileExport> files = filesOfTheOnlyRepository(landscapeConfigFile);
+
+        assertEquals(ALL_SCOPES, describe(files));
+    }
+
+    @Test
+    public void theDefaultAspectNamesAreReadAsBefore() throws Exception {
+        // Every existing landscape reads these names; a derivation that produced something subtly
+        // different - "aspect_build_and_deployment" is getSafeFileName's doing, not an obvious
+        // transformation of "build and deployment" - would empty every repository in it.
+        CodeConfiguration configuration = CodeConfiguration.getDefaultConfiguration();
+        File landscapeConfigFile = landscapeOverRepository(configuration);
+
+        List<FileExport> files = filesOfTheOnlyRepository(landscapeConfigFile);
+
+        assertEquals(ALL_SCOPES, describe(files));
+    }
+
+    @Test
+    public void aRepositoryWithoutAConfigurationIsReadUnderTheDefaultNames() throws Exception {
+        // Nothing guarantees a readable config.json next to the analysis results: a data folder can
+        // be missing one, and an unparseable one leaves the configuration null just the same -
+        // JsonMapper turns a parse error into an IllegalArgumentException, which the catch in
+        // getRepositoryAnalysisResults swallows. The default names are then the best remaining guess,
+        // and what such a repository was read under before the names followed the configuration.
+        File landscapeConfigFile = landscapeOverRepository(CodeConfiguration.getDefaultConfiguration());
+        assertTrue(configFileOf(landscapeConfigFile).delete());
+
+        List<FileExport> files = filesOfTheOnlyRepository(landscapeConfigFile);
+
+        assertEquals(ALL_SCOPES, describe(files));
+    }
+
+    @Test
+    public void aScopeSetToNullInTheConfigurationIsReadUnderItsDefaultName() throws Exception {
+        // config.json is hand-edited, and of the five scope setters only setMain rejects a null - so
+        // "test": null reaches the analyzer as a null aspect. Asking it for its name would throw out
+        // of analyze(), whose only handler catches IOException, taking the whole landscape with it.
+        File landscapeConfigFile = landscapeOverRepository(CodeConfiguration.getDefaultConfiguration());
+        write(configFileOf(landscapeConfigFile), "{\"test\": null}");
+
+        List<FileExport> files = filesOfTheOnlyRepository(landscapeConfigFile);
+
+        assertEquals(ALL_SCOPES, describe(files));
+    }
+
+    @Test
+    public void theFileListNamesFollowTheAspectNames() {
+        CodeConfiguration configuration = CodeConfiguration.getDefaultConfiguration();
+
+        assertEquals("aspect_main.txt", LandscapeAnalyzer.scopeFileListName(configuration.getMain()));
+        assertEquals("aspect_build_and_deployment.txt",
+                LandscapeAnalyzer.scopeFileListName(configuration.getBuildAndDeployment()));
+
+        configuration.getMain().setName("production code");
+        assertEquals("aspect_production_code.txt", LandscapeAnalyzer.scopeFileListName(configuration.getMain()));
+    }
+
+    /**
+     * A landscape over one repository holding a file in each scope, exported the way the given
+     * configuration names its file lists. The loose-file layout (no data.zip) is one the analyzer
+     * still reads, and keeps the fixture to plain files.
+     */
+    private File landscapeOverRepository(CodeConfiguration configuration) throws IOException {
+        File root = Files.createTempDirectory("landscape-scope-file-lists").toFile();
+        root.deleteOnExit();
+
+        File dataFolder = new File(root, "repository/_sokrates/reports/data");
+        write(new File(dataFolder, "analysisResults.json"), "{\"metadata\": {\"name\": \"Repository\"}}");
+        write(new File(dataFolder, "config.json"), new JsonGenerator().generate(configuration));
+
+        writeFileList(dataFolder, configuration.getMain(), "src/A.java\t10\nsrc/B.java\t20\n");
+        writeFileList(dataFolder, configuration.getTest(), "src/ATest.java\t5\n");
+        writeFileList(dataFolder, configuration.getGenerated(), "gen/G.java\t7\n");
+        writeFileList(dataFolder, configuration.getBuildAndDeployment(), "build/deploy.sh\t3\n");
+        writeFileList(dataFolder, configuration.getOther(), "docs/notes.md\t1\n");
+
+        File landscapeConfigFile = new File(root, "_sokrates_landscape/config.json");
+        write(landscapeConfigFile, "{\"analysisRoot\": \"" + root.getAbsolutePath() + "\"}");
+        // The repositories of a landscape live in info.json, next to its config.json.
+        write(new File(landscapeConfigFile.getParentFile(), "info.json"),
+                "{\"repositories\": [{\"analysisResultsPath\":"
+                        + " \"repository/_sokrates/reports/data/analysisResults.json\"}]}");
+        return landscapeConfigFile;
+    }
+
+    /** Written under the name the exporter derives from the aspect, not under a literal. */
+    private void writeFileList(File dataFolder, NamedSourceCodeAspect aspect, String rows) throws IOException {
+        String fileName = "aspect_" + aspect.getFileSystemFriendlyName("") + ".txt";
+        write(new File(dataFolder, "text/" + fileName), "Path\tLines of Code\n" + rows);
+    }
+
+    private File configFileOf(File landscapeConfigFile) {
+        return new File(landscapeConfigFile.getParentFile().getParentFile(),
+                "repository/_sokrates/reports/data/config.json");
+    }
+
+    private List<FileExport> filesOfTheOnlyRepository(File landscapeConfigFile) {
+        List<RepositoryAnalysisResults> repositories =
+                new LandscapeAnalyzer().analyze(landscapeConfigFile).getRepositoryAnalysisResults();
+        assertEquals(1, repositories.size());
+        return repositories.get(0).getFiles();
+    }
+
+    /** Scope and path of each file, so a file found under the wrong scope fails too. */
+    private String describe(List<FileExport> files) {
+        return files.stream().map(file -> file.getScope() + "/" + file.getPath()).collect(Collectors.toList()).toString();
+    }
+
+    private void write(File file, String content) throws IOException {
+        FileUtils.write(file, content, StandardCharsets.UTF_8);
+    }
+}


### PR DESCRIPTION
**A repository that renames a scope aspect in `config.json` loses that scope's files from every landscape it appears in** — the landscape reports a smaller repository, with no exception, nothing in the log and an exit code of `0`.

## How it happens

`LandscapeAnalyzer.getRepositoryFiles` reads each repository's five scope file lists by literal name:

```java
files.addAll(getRepositoryFilesByScope(repositoryName, link, "aspect_main.txt"));
```

but the exporter derives each name from the aspect's **configured** name, via `DataExportUtils.getAspectFileListFileName` → `getSafeFileName(prefix + name)`. The default names produce exactly those five literals, so the two sides agree in every ordinary landscape — until someone renames an aspect. `main` renamed to `production code` is written as `text/aspect_production_code.txt`; the read asks for `text/aspect_main.txt`, which is not in the repository's `data.zip`.

A missing entry reads as `null` here, so the scope contributes an empty list. That is quieter than the same defect in `DataExporter` (#111), which at least threw.

## Measured

Two fixture repositories with identical source, analysed and then aggregated into one landscape. They differ only in `main.name`:

| `main.name` | files contributed to the landscape | | --- | --- |
| `main` (what `init` writes) | 3 main, 2 test, 2 build | | `production code` (renamed) | **0 main**, 2 test, 2 build |

The landscape's `files.json` held 11 files instead of 14, and its files explorer showed and counted the repository accordingly. After this change both repositories contribute all 7 of their files, and the landscape is symmetric.

## The change

The names come from the repository's own `config.json`, which the analyzer already reads next to `analysisResults.json`. The default names remain the fallback, per scope: the whole configuration is `null` for a repository exported without a readable `config.json`, and a single aspect is `null` when a `config.json` sets that scope to `null` — of the five setters only `setMain` rejects one. The default name is then the best remaining guess, and is what such a repository was read under before this change, so nothing gets worse.

The scope a file is reported under is now passed separately instead of being recovered from the file name. It was the file name (`"aspect_main.txt"`), which the files explorer had to strip back to `main` in the browser; once the name is configuration, that recovery no longer works — a renamed aspect's files would land in the explorer's `other` bucket. Files now carry `main` / `test` / `generated` / `build` / `other`, the same scope keys the per-repository files explorer already exports, and the explorer's existing normalisation leaves them untouched.

## Why it is safe for existing landscapes

- **Default configurations read exactly the same five files as before**, in the same order. A test asserts that against hard-coded literals rather than against the deriving function, so it cannot pass by agreeing with itself.
- **The `scope` values in the landscape's `files.json` change** for every repository, from `aspect_main.txt` to `main`. The only consumer is `files-explorer.html`, which already accepted both forms; the per-repository files explorer has always written the short keys.
- Repositories exported before `data/` was packaged into `data.zip` are read through the existing loose-file fallback, untouched here.
- A repository whose `config.json` cannot be read falls back to the default names — which is what every repository was read under before this change. That covers a data folder without one (it has been copied into `data/` since 2020, so this means a pruned or externally assembled folder) and, more usefully, an unparseable one: `JsonMapper` turns a Jackson parse error into an `IllegalArgumentException`, which the `catch (RuntimeException)` in `getRepositoryAnalysisResults` already swallows, leaving the configuration null.
- The two `excluded_files_ignored_*.txt` lists keep their literal names, since the exporter writes those literally too. They are written as prose (`*.png files (1):` and then bare paths, no tab-separated rows), so no file has ever been parsed out of them; the scope now passed for them is inert.

## Tests

Five, in a new `LandscapeAnalyzerScopeFileListsTest`, all going through `analyze(...)` over a small on-disk landscape holding a file in each of the five scopes: a renamed scope aspect still contributes its files, the default names are read as before, a repository with no `config.json` falls back to the default names, a scope set to `null` in `config.json` falls back to its default name, and the file-list names follow the aspect names.

Each was checked by mutation — ignoring the repository's configuration, taking the scope from the file name again, mislabelling one scope, deriving the name from `getName()` instead of `getFileSystemFriendlyName("")`, and dropping the per-scope fallback each fail at least one test, with the failure naming the defect.

Follow-up to #111, which fixed the same defect in `DataExporter` and flagged this one.