### PR TITLE
Halve the time duplication analysis spends pairing files

### DIFF
--- a/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/duplication/impl/Blocks.java
+++ b/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/duplication/impl/Blocks.java
@@ -9,14 +9,13 @@ import nl.obren.sokrates.sourcecode.SourceFile;
 import nl.obren.sokrates.sourcecode.cleaners.CleanedContent;
 import nl.obren.sokrates.sourcecode.duplication.DuplicatedFileBlock;
 import nl.obren.sokrates.sourcecode.duplication.DuplicationInstance;
-import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.Pair;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -28,10 +27,12 @@ public class Blocks {
     private int endProgressValue = 0;
     private boolean optimize = true;
 
-    private Map<String, Pair<SourceFile, SourceFile>> filePairMap = new HashMap<>();
+    // The pairs of files sharing at least one duplicated block - what findDuplicatesAmongFiles below
+    // compares. A pair is unordered, and a block shared among k files contributes k*(k-1)/2 of them, so
+    // this is the structure that grows fastest on a clone-dense repository.
+    private Set<FilePair> filePairs = new HashSet<>();
 
     private List<Block> blocksDuplicatedAmongFiles = new ArrayList<>();
-    private List<Block> duplicatedFilePairs = new ArrayList<>();
     private List<Block> duplicateBlocks = new ArrayList<>();
     private ProgressFeedback progressFeedback;
     // The two find loops below run in parallel; these maps are shared across worker threads.
@@ -82,37 +83,26 @@ public class Blocks {
         blocksDuplicatedAmongFiles.forEach(db -> {
             reportProgressNextStep();
             if (db.getFiles().size() == 2) {
-                duplicatedFilePairs.add(db);
                 SourceFile sourceFile1 = db.getFiles().get(0);
                 SourceFile sourceFile2 = db.getFiles().get(1);
-                String pairKey1 = getPairKey(sourceFile1.getFile().getPath(), sourceFile2.getFile().getPath());
-                String pairKey2 = getPairKey(sourceFile2.getFile().getPath(), sourceFile1.getFile().getPath());
-
-                if (!(filePairMap.containsKey(pairKey1) || filePairMap.containsKey(pairKey2))) {
-                    filePairMap.put(pairKey1, new ImmutablePair<>(sourceFile1, sourceFile2));
-                }
+                filePairs.add(new FilePair(sourceFile1, sourceFile2));
             } else if (db.getFiles().size() > 2) {
-                db.getFiles().forEach(f1 -> {
-                    db.getFiles().stream().filter(f2 -> f1 != f2).forEach(f2 -> {
-                        Block newBlock = new Block();
-                        duplicatedFilePairs.add(newBlock);
-                        newBlock.setLineIndexes(db.getLineIndexes());
-                        newBlock.getFiles().add(f1);
-                        newBlock.getFiles().add(f2);
+                List<SourceFile> filesSharingBlock = db.getFiles();
+                for (int i = 0; i < filesSharingBlock.size(); i++) {
+                    for (int j = i + 1; j < filesSharingBlock.size(); j++) {
+                        SourceFile f1 = filesSharingBlock.get(i);
+                        SourceFile f2 = filesSharingBlock.get(j);
 
-                        String pairKey1 = getPairKey(f1.getFile().getPath(), f2.getFile().getPath());
-                        String pairKey2 = getPairKey(f2.getFile().getPath(), f1.getFile().getPath());
-
-                        if (!(filePairMap.containsKey(pairKey1) || filePairMap.containsKey(pairKey2))) {
-                            filePairMap.put(pairKey1, new ImmutablePair(f1, f2));
-                        }
-                    });
-                });
+                        filePairs.add(new FilePair(f1, f2));
+                    }
+                }
             }
         });
         resetProgressValues(0);
     }
 
+    // Still used by the fileRangePairs map below, which is keyed per matched block pair rather than
+    // per file pair.
     private String getPairKey(String path1, String path2) {
         return new StringBuilder()
                 .append(path1)
@@ -121,17 +111,58 @@ public class Blocks {
                 .toString();
     }
 
+    /**
+     * An unordered pair of files, identified by the two paths. SourceFile overrides equals but not
+     * hashCode, so identity is derived from the paths directly; the strings are the ones the files
+     * already hold, so a pair costs its own object and nothing more.
+     */
+    private static final class FilePair {
+        private final SourceFile file1;
+        private final SourceFile file2;
+        private final String path1;
+        private final String path2;
+        private final int hash;
+
+        private FilePair(SourceFile fileA, SourceFile fileB) {
+            String pathA = fileA.getFile().getPath();
+            String pathB = fileB.getFile().getPath();
+            boolean inOrder = pathA.compareTo(pathB) <= 0;
+            this.file1 = inOrder ? fileA : fileB;
+            this.file2 = inOrder ? fileB : fileA;
+            this.path1 = inOrder ? pathA : pathB;
+            this.path2 = inOrder ? pathB : pathA;
+            this.hash = 31 * path1.hashCode() + path2.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            }
+            if (!(other instanceof FilePair)) {
+                return false;
+            }
+            FilePair otherPair = (FilePair) other;
+            return path1.equals(otherPair.path1) && path2.equals(otherPair.path2);
+        }
+
+        @Override
+        public int hashCode() {
+            return hash;
+        }
+    }
+
     private void findDuplicatesAmongFiles() {
-        resetProgressValues(filePairMap.size());
+        resetProgressValues(filePairs.size());
         reportProgress("Finding duplicates among files");
 
-        filePairMap.values().parallelStream().forEach(pair -> {
+        filePairs.parallelStream().forEach(pair -> {
             if (progressFeedback != null && progressFeedback.canceled()) {
                 return;
             }
             reportProgressNextStep();
-            SourceFile f1 = pair.getLeft();
-            SourceFile f2 = pair.getRight();
+            SourceFile f1 = pair.file1;
+            SourceFile f2 = pair.file2;
 
             // Both files must be thread-local copies: addDuplicationInstances calls extractBlocks() on
             // file1, which mutates that FileInfoForDuplication's internal blocks list. The shared originals

--- a/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/duplication/DuplicationEngineSharedBlockTest.java
+++ b/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/duplication/DuplicationEngineSharedBlockTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2021 Željko Obrenović. All rights reserved.
+ */
+
+package nl.obren.sokrates.sourcecode.duplication;
+
+import nl.obren.sokrates.common.utils.ProgressFeedback;
+import nl.obren.sokrates.sourcecode.SourceFile;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * A block shared among more than two files.
+ *
+ * <p>That is the branch where the engine enumerates the file pairs of one duplicated block. The
+ * existing DuplicationEngineTest only covers two files, where there is exactly one pair and nothing
+ * to enumerate; with three files the pairing is what decides which duplication instances come out.
+ */
+public class DuplicationEngineSharedBlockTest {
+
+    @Test
+    public void aBlockSharedAmongThreeFilesYieldsOneInstanceOverAllThree() {
+        String shared = "alpha\nbeta\ngamma\ndelta\nepsilon\nzeta\n";
+        List<SourceFile> sourceFiles = Arrays.asList(
+                new SourceFile(new File("c.unknown"), shared + "tail c\n"),
+                new SourceFile(new File("a.unknown"), shared + "tail a\n"),
+                new SourceFile(new File("b.unknown"), shared + "tail b\n"));
+
+        List<DuplicationInstance> duplicates =
+                new DuplicationEngine().findDuplicates(sourceFiles, 6, new ProgressFeedback());
+
+        assertEquals("{[a.unknown, b.unknown, c.unknown]=1}", describe(duplicates));
+    }
+
+    @Test
+    public void everyPairIsCompared() {
+        // The case above cannot detect a lost pair: all three files hold the same block, so the
+        // instances merge and one surviving pair drags the rest in. Here each pair also shares a block
+        // that the third file does not have, and d/e share one with nobody else - so dropping any pair,
+        // or giving two pairs the same identity, loses instances nothing can recover.
+        String all = "alpha\nbeta\ngamma\ndelta\nepsilon\nzeta\n";
+        String ab = "ab1\nab2\nab3\nab4\nab5\nab6\n";
+        String ac = "ac1\nac2\nac3\nac4\nac5\nac6\n";
+        String bc = "bc1\nbc2\nbc3\nbc4\nbc5\nbc6\n";
+        String de = "de1\nde2\nde3\nde4\nde5\nde6\n";
+        List<SourceFile> sourceFiles = Arrays.asList(
+                new SourceFile(new File("c.unknown"), all + ac + bc + "tail c\n"),
+                new SourceFile(new File("a.unknown"), all + ab + ac + "tail a\n"),
+                new SourceFile(new File("b.unknown"), all + ab + bc + "tail b\n"),
+                new SourceFile(new File("d.unknown"), de + "tail d\n"),
+                new SourceFile(new File("e.unknown"), de + "tail e\n"));
+
+        List<DuplicationInstance> duplicates =
+                new DuplicationEngine().findDuplicates(sourceFiles, 6, new ProgressFeedback());
+
+        assertEquals("{[a.unknown, b.unknown, c.unknown]=1, [a.unknown, b.unknown]=6, [a.unknown, c.unknown]=1, [b.unknown, c.unknown]=1, [d.unknown, e.unknown]=1}", describe(duplicates));
+    }
+
+    /** How many duplication instances each set of files takes part in - order-independent. */
+    private String describe(List<DuplicationInstance> duplicates) {
+        Map<String, Integer> countsByFileSet = new TreeMap<>();
+        for (DuplicationInstance duplicate : duplicates) {
+            List<String> names = duplicate.getDuplicatedFileBlocks().stream()
+                    .map(block -> block.getSourceFile().getFile().getName())
+                    .sorted()
+                    .collect(Collectors.toList());
+            countsByFileSet.merge(names.toString(), 1, Integer::sum);
+        }
+        return countsByFileSet.toString();
+    }
+}


### PR DESCRIPTION
**Duplication analysis allocates millions of objects it never reads.** For a block shared among k files, `Blocks.createDuplicatedFilesMap` builds a fresh `Block` per **ordered** pair — k·(k−1) of them, each carrying the same `lineIndexes` — and appends them to `duplicatedFilePairs`. That list is private, has no getter, and is read nowhere in the codebase. Every one of those objects is garbage the moment it is created.

Alongside it, the file pairs themselves were held in a `Map` keyed on `"path1::path2"`, built by concatenating two full paths. Each pair cost two such keys (both orders, to test membership) and retained one for the life of the run.

## The change

- Enumerate each pair once (`i < j`) instead of both orders, and stop building the `Block` objects and the write-only list entirely.
- Hold the pairs in a `Set<FilePair>`, where `FilePair` keeps the two `SourceFile` references and derives identity from their paths. Nothing is allocated per pair beyond the entry itself. (`SourceFile` overrides `equals` but not `hashCode`, so the paths are used directly rather than the files.)

`getPairKey` stays — the separate `fileRangePairs` map, keyed per matched block pair, still uses it.

## Measured

A synthetic clone-dense repository: 1,351 files, 12.6 MB of main code, every file drawing its method bodies from a pool of 200 blocks. `generateReports`, JDK 25, `-Xmx4g`, best of the runs below.

| | duplication analysis | whole run |
| --- | --- | --- |
| before | 27.6 s | 34.0 s |
| after | **13.9 s** | **19.0 s** |

**Results are identical**, not merely similar: same 10,000 exported instances, same 9,692 distinct (block size, file set) keys, `DUPLICATION_NUMBER_OF_DUPLICATED_LINES` 406,651 and `DUPLICATION_PERCENTAGE` 99.669 before and after.

One case is not merely identical but strictly better, and only in theory: the old `"path1::path2"` key conflated two different pairs whose concatenations collide — paths `("a::b", "c")` and `("a", "b::c")` produce the same key, so one pair was silently dropped. `FilePair` keeps the two paths as separate fields. No real filesystem reaches this.

## What this does not do

It does not reduce peak memory, and I would rather say so than let the diff imply otherwise. Peak RSS on that corpus is ~4.2 GB before and after, and a 2 GB heap still fails. A heap histogram taken at the peak shows why: 8.3 M `DuplicationInstance` objects and 16.9 M `DuplicatedFileBlock` objects — the retained result set, not the pairing structures. The objects removed here were transient garbage, so the win is in GC pressure and time.

## Tests

`DuplicationEngineSharedBlockTest` covers a block shared among more than two files — the branch that does the enumerating; the existing `DuplicationEngineTest` only has two files, where there is exactly one pair and nothing to enumerate. Its second case gives every pair a block the third file does not have, and a further pair of files sharing a block with nobody else, so a dropped or conflated pair loses instances that nothing else can recover.

Both expectations were taken from the **unmodified** engine and then re-run against the change, so they characterise existing behaviour rather than agreeing with the new code. Mutation-checked: pairing a file with itself (`j = i`), recording no pair in either the two-file or the many-file branch, and giving two pairs the same identity each fail the test. Making the pair order non-canonical does not — the fixture happens to enumerate each pair consistently, and the old two-key membership check made that case unobservable too.