### PR TITLE
Find dependencies on PL/SQL packages with names outside ASCII

### DIFF
--- a/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/lang/plsql/PlSqlHeuristicDependenciesExtractor.java
+++ b/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/lang/plsql/PlSqlHeuristicDependenciesExtractor.java
@@ -70,7 +70,7 @@ public class PlSqlHeuristicDependenciesExtractor extends HeuristicDependenciesEx
         String fileNameNoExtension = FilenameUtils.removeExtension(sourceFile.getFile().getName());
         CleanedContent cleanedContent = getCleanContent(sourceFile);
         List<String> lines = SourceCodeCleanerUtils.splitInLines(cleanedContent.getCleanedContent());
-        Pattern pattern = Pattern.compile("\\w+[.][a-zA-Z]+");
+        Pattern pattern = Pattern.compile("[\\p{L}\\p{N}_][\\p{L}\\p{M}\\p{N}_]*[.]\\p{L}[\\p{L}\\p{M}]*");
         Matcher matcher = null;
         List<String> packages = new ArrayList<>();
         for (String line : lines) {

--- a/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/lang/plsql/PlSqlDependenciesWithNonAsciiNamesTest.java
+++ b/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/lang/plsql/PlSqlDependenciesWithNonAsciiNamesTest.java
@@ -1,0 +1,152 @@
+package nl.obren.sokrates.sourcecode.lang.plsql;
+
+import nl.obren.sokrates.common.utils.ProgressFeedback;
+import nl.obren.sokrates.sourcecode.SourceFile;
+import nl.obren.sokrates.sourcecode.dependencies.Dependency;
+import nl.obren.sokrates.sourcecode.dependencies.DependencyAnchor;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * A caller of a package whose name is not written in ASCII must produce the same dependency as
+ * an otherwise identical ASCII caller. The counts are compared against the ASCII twin rather than
+ * against a literal, so the test states the property instead of the current numbers.
+ */
+public class PlSqlDependenciesWithNonAsciiNamesTest {
+
+    private static final String ASCII_PACKAGE = "paket";
+    private static final String ASCII_PROCEDURE = "funktion";
+
+    private String packageSource(String packageName, String procedureName) {
+        return "CREATE OR REPLACE PACKAGE " + packageName + " AS\n" +
+                "   PROCEDURE " + procedureName + ";\n" +
+                "END " + packageName + ";\n";
+    }
+
+    private String callerSource(String packageName, String procedureName) {
+        return "DECLARE\n" +
+                "   code number := 8;\n" +
+                "BEGIN\n" +
+                "   " + packageName + "." + procedureName + ";\n" +
+                "END;";
+    }
+
+    private List<Dependency> dependencies(String packageName, String procedureName) {
+        SourceFile declaration = new SourceFile(new File("package.pls"), packageSource(packageName, procedureName));
+        SourceFile caller = new SourceFile(new File("caller.pls"), callerSource(packageName, procedureName));
+
+        return new PlSqlAnalyzer()
+                .extractDependencies(Arrays.asList(declaration, caller), new ProgressFeedback())
+                .getDependencies();
+    }
+
+    private void assertSameDependencyAsAsciiTwin(String packageName, String procedureName) {
+        List<Dependency> ascii = dependencies(ASCII_PACKAGE, ASCII_PROCEDURE);
+        List<Dependency> nonAscii = dependencies(packageName, procedureName);
+
+        assertEquals(1, ascii.size());
+        assertEquals("caller -> " + ASCII_PACKAGE, ascii.get(0).getDependencyString());
+
+        assertEquals(ascii.size(), nonAscii.size());
+        assertEquals("caller -> " + packageName, nonAscii.get(0).getDependencyString());
+    }
+
+    @Test
+    public void cyrillicPackageName() {
+        assertSameDependencyAsAsciiTwin("пакет", "функция");
+    }
+
+    @Test
+    public void greekPackageName() {
+        assertSameDependencyAsAsciiTwin("πακέτο", "λειτουργία");
+    }
+
+    /**
+     * A name written in the Latin alphabet is only lost when a non-ASCII letter sits on both sides
+     * of the dot, because an ASCII letter anywhere next to it satisfies the old pattern by itself.
+     */
+    @Test
+    public void germanPackageNameEndingInANonAsciiLetter() {
+        assertSameDependencyAsAsciiTwin("maß", "änderung");
+    }
+
+    @Test
+    public void nordicPackageNameEndingInANonAsciiLetter() {
+        assertSameDependencyAsAsciiTwin("verdi_blå", "økning");
+    }
+
+    /**
+     * {@code \w} admitted digits, so the widened class has to as well. A package named
+     * {@code paket2} is ordinary in PL/SQL, and losing it would be a regression against ASCII
+     * input rather than a gap left in it.
+     */
+    @Test
+    public void aDigitInThePackageNameIsStillAllowed() {
+        List<Dependency> dependencies = dependencies("paket2", "funktion");
+
+        assertEquals(1, dependencies.size());
+        assertEquals("caller -> paket2", dependencies.get(0).getDependencyString());
+    }
+
+    /**
+     * An accented letter may be stored decomposed, as a base letter followed by a combining mark.
+     * A class of letters alone breaks off at the mark, so the mark has to be admitted in the tail.
+     */
+    @Test
+    public void decomposedAccentBehavesLikeAPrecomposedOne() {
+        List<Dependency> precomposed = dependencies("paketé", "funktioné");
+        List<Dependency> decomposed = dependencies("pakete\u0301", "funktione\u0301");
+
+        assertEquals(1, precomposed.size());
+        assertEquals(precomposed.size(), decomposed.size());
+        assertEquals("caller -> pakete\u0301", decomposed.get(0).getDependencyString());
+    }
+
+    /**
+     * The same must hold on the far side of the dot. A class of letters alone ends the member name
+     * at the mark and then reads the rest of it as a second, invented reference: the decomposed
+     * form of {@code foo.béz.qux} yields the packages {@code foo} and {@code z} rather than only
+     * {@code foo}, and the file is given an anchor for each.
+     */
+    @Test
+    public void aDecomposedAccentInAMemberNameDoesNotSplitTheReference() {
+        assertEquals(anchorsOf("   foo.béz.qux;\n").size(),
+                anchorsOf("   foo.be\u0301z.qux;\n").size());
+    }
+
+    private List<DependencyAnchor> anchorsOf(String bodyLine) {
+        SourceFile caller = new SourceFile(new File("caller.pls"),
+                "DECLARE\n" +
+                        "   code number := 8;\n" +
+                        "BEGIN\n" +
+                        bodyLine +
+                        "END;");
+
+        return new PlSqlHeuristicDependenciesExtractor().extractDependencyAnchors(caller);
+    }
+
+    /**
+     * A combining mark that begins a token is garbled input rather than a name, so it must not be
+     * read as a qualified reference and turn the file into a dependency source.
+     */
+    @Test
+    public void strayCombiningMarkIsNotAQualifiedReference() {
+        SourceFile caller = new SourceFile(new File("caller.pls"),
+                "DECLARE\n" +
+                        "   code number := 8;\n" +
+                        "BEGIN\n" +
+                        "   \u0301.funktion;\n" +
+                        "END;");
+
+        List<DependencyAnchor> anchors = new PlSqlHeuristicDependenciesExtractor()
+                .extractDependencyAnchors(caller);
+
+        assertTrue(anchors.isEmpty());
+    }
+}


### PR DESCRIPTION
A PL/SQL file becomes a source of dependencies only once it is seen to make a qualified reference, which is decided by matching \w+[.][a-zA-Z]+ against its lines. Both halves of that pattern are ASCII: \w is ASCII-only in Java unless UNICODE_CHARACTER_CLASS is set, and [a-zA-Z] is ASCII by construction. A file whose calls read пакет.функция or πακέτο.λειτουργία matches nothing, is given no dependency anchor, and is dropped from the dependency graph. Nothing reports that anything was skipped, and a missing edge looks exactly like an absence of dependencies.

Only files without a package declaration of their own lose their edges. A package body is already an anchor by virtue of its declaration, which is found by string search and needs no regex; anonymous blocks, standalone procedures and test scripts are what vanish. Lines of code, units and duplication are untouched, because the file is still read and counted.

Measured on utPLSQL, 185 PL/SQL files, with every package name declared in that corpus mechanically transliterated to Cyrillic. The names were taken from package declarations only - the statement head of a line, optionally preceded by CREATE OR REPLACE and an EDITIONABLE or NONEDITIONABLE marker - with SQL keywords excluded, so that Oracle built-ins, keywords and prose keep their ASCII spelling. The marker is worth spelling out: 54 of the 185 files declare that way, ut among them, and twenty of the twenty-one recovered edges point at ut:

  before    82 edges     593 edge instances
  after    103 edges    1006 edge instances

Twenty-one edges recovered, none lost and none altered. Across the same corpora unmodified - utPLSQL, alexandria-plsql-utils and oracle-db-examples, 311 PL/SQL files and 102 edges between them - the dependency lists before and after are identical, because those names are written in ASCII and widening a class of ASCII letters cannot change what ASCII input matches.

The class is widened as the unit extractors were in #105: \p{L} and \p{N} for letters and digits, with \p{M} admitted in the tail. An accented character may be stored decomposed, as a base letter followed by a combining mark, and a class of letters alone breaks off at the mark. The mark is not admitted at the head, because a mark that begins a token is garbled input rather than a name, and letting one start a match reads a line of noise as a qualified reference. The shape of the pattern is otherwise preserved, including that a leading digit is still allowed, as \w allowed one.

The other ASCII-anchored pattern in dependency extraction, PHP's [a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*, is left alone. It mirrors PHP's own identifier grammar rather than being an oversight, so widening it would take a position on the language spec; against a decoded Java string it admits U+007F-U+00FF, which covers Latin-1 but not Latin Extended-A, Greek or Cyrillic. Worth revisiting only if someone shows a real failure.

PlSqlDependenciesWithNonAsciiNamesTest asserts that a Cyrillic, Greek, German or Nordic package name yields the same dependency as its ASCII twin, rather than asserting a particular count, and pins the edge cases one at a time. Reverting the pattern fails five of its eight tests. Five further mutations fail exactly one test each: admitting \p{M} at the head, or dropping the first-character class altogether, fails the stray-mark test; dropping \p{M} from the class before the dot fails the decomposed-accent test; dropping it from the class after the dot fails the member-name test, where a mark inside a member name would otherwise end the name and leave the remainder to be read as a second reference that was never written - foo.b́z.qux yielding foo and z rather than foo alone; and dropping \p{N} fails the digit test, since \w admitted digits and a package named paket2 has to keep matching.

The underscore is the one part with no test behind it. Removing it from either class only moves where a match starts, because a name that contains one still has a letter or a digit somewhere to begin at, and no dependency changes as a result. It is kept because \w had it, not because anything here would notice if it went.