### PR TITLE
Anchor a PL/SQL package body to the package it implements

### DIFF
--- a/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/lang/plsql/PlSqlHeuristicDependenciesExtractor.java
+++ b/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/lang/plsql/PlSqlHeuristicDependenciesExtractor.java
@@ -16,6 +16,7 @@ import java.util.regex.Pattern;
 
 public class PlSqlHeuristicDependenciesExtractor extends HeuristicDependenciesExtractor {
     public static final String PACKAGE_PREFIX = "PACKAGE ";
+    public static final String BODY_KEYWORD = "BODY";
 
     @Override
     public List<DependencyAnchor> extractDependencyAnchors(SourceFile sourceFile) {
@@ -42,11 +43,13 @@ public class PlSqlHeuristicDependenciesExtractor extends HeuristicDependenciesEx
             startIndexOfPackageName = content.indexOf(PACKAGE_PREFIX.toLowerCase());
         }
         if (startIndexOfPackageName >= 0) {
-            int endIndexOfPackageName = content.indexOf(" ",
-                    startIndexOfPackageName + PACKAGE_PREFIX.length());
+            int startOfName = skipWhitespace(content, startIndexOfPackageName + PACKAGE_PREFIX.length());
+            if (isBodyKeywordAt(content, startOfName)) {
+                startOfName = skipWhitespace(content, startOfName + BODY_KEYWORD.length());
+            }
+            int endIndexOfPackageName = indexOfWhitespace(content, startOfName);
             if (endIndexOfPackageName >= 0) {
-                String packageName = content.substring(startIndexOfPackageName + PACKAGE_PREFIX.length(),
-                        endIndexOfPackageName).trim();
+                String packageName = content.substring(startOfName, endIndexOfPackageName).trim();
                 String codeFragment = content.substring(startIndexOfPackageName,
                         endIndexOfPackageName + 1).trim();
                 anchors.add((createAnchor(packageName, codeFragment, sourceFile)));
@@ -54,6 +57,30 @@ public class PlSqlHeuristicDependenciesExtractor extends HeuristicDependenciesEx
         }
 
         return anchors;
+    }
+
+    private boolean isBodyKeywordAt(String content, int index) {
+        int afterKeyword = index + BODY_KEYWORD.length();
+        return content.regionMatches(true, index, BODY_KEYWORD, 0, BODY_KEYWORD.length())
+                && afterKeyword < content.length()
+                && Character.isWhitespace(content.charAt(afterKeyword));
+    }
+
+    private int skipWhitespace(String content, int fromIndex) {
+        int index = fromIndex;
+        while (index < content.length() && Character.isWhitespace(content.charAt(index))) {
+            index++;
+        }
+        return index;
+    }
+
+    private int indexOfWhitespace(String content, int fromIndex) {
+        for (int i = fromIndex; i < content.length(); i++) {
+            if (Character.isWhitespace(content.charAt(i))) {
+                return i;
+            }
+        }
+        return -1;
     }
 
     private DependencyAnchor createAnchor(String packageName, String code, SourceFile sourceFile) {

--- a/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/lang/plsql/PlSqlPackageBodyAnchorTest.java
+++ b/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/lang/plsql/PlSqlPackageBodyAnchorTest.java
@@ -1,0 +1,124 @@
+package nl.obren.sokrates.sourcecode.lang.plsql;
+
+import nl.obren.sokrates.sourcecode.SourceFile;
+import nl.obren.sokrates.sourcecode.dependencies.DependencyAnchor;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * A package body belongs to the package it implements. The declaration is read by string search,
+ * and the name has to be taken from after the BODY keyword rather than from it: every body in the
+ * codebase otherwise anchors under the same name, and a node that is not a package collects their
+ * dependencies.
+ *
+ * <p>The file names here deliberately differ from the package names, so that the anchor under test
+ * is the one taken from the declaration and not the one taken from the file name.
+ */
+public class PlSqlPackageBodyAnchorTest {
+
+    private static final String SPEC =
+            "CREATE OR REPLACE PACKAGE pkg_a AS\n" +
+            "   PROCEDURE run;\n" +
+            "END pkg_a;\n";
+
+    private static final String BODY =
+            "CREATE OR REPLACE PACKAGE BODY pkg_a AS\n" +
+            "   PROCEDURE run IS\n" +
+            "   BEGIN\n" +
+            "      NULL;\n" +
+            "   END run;\n" +
+            "END pkg_a;\n";
+
+    private List<String> anchorNames(SourceFile... files) {
+        return new PlSqlHeuristicDependenciesExtractor()
+                .getDependencyAnchors(Arrays.asList(files)).stream()
+                .map(DependencyAnchor::getAnchor)
+                .sorted()
+                .collect(Collectors.toList());
+    }
+
+    private SourceFile file(String name, String content) {
+        return new SourceFile(new File(name), content);
+    }
+
+    @Test
+    public void aPackageBodyAnchorsUnderThePackageName() {
+        assertEquals(Arrays.asList("pkg_a"), anchorNames(file("a_body.pkb", BODY)));
+    }
+
+    /**
+     * The defect this pins: with the name taken from the BODY keyword, both files anchor under
+     * "BODY" and merge into one node, so a codebase that keeps bodies in their own files loses
+     * every package body as a distinct component.
+     */
+    @Test
+    public void twoPackageBodiesDoNotMergeIntoOneAnchor() {
+        assertEquals(Arrays.asList("pkg_a", "pkg_b"), anchorNames(
+                file("a_body.pkb", BODY),
+                file("b_body.pkb", BODY.replace("pkg_a", "pkg_b"))));
+    }
+
+    @Test
+    public void theSpecAndTheBodyShareOneAnchor() {
+        List<DependencyAnchor> anchors = new PlSqlHeuristicDependenciesExtractor()
+                .getDependencyAnchors(Arrays.asList(file("a_spec.pks", SPEC), file("a_body.pkb", BODY)));
+
+        assertEquals(1, anchors.size());
+        assertEquals("pkg_a", anchors.get(0).getAnchor());
+        assertEquals(2, anchors.get(0).getSourceFiles().size());
+    }
+
+    /**
+     * Real PL/SQL puts the AS or IS on the next line as often as not. The name ends at the first
+     * whitespace, not at the first space, or it runs on into the rest of the declaration.
+     */
+    @Test
+    public void aNameEndingAtALineBreakIsReadWhole() {
+        assertEquals(Arrays.asList("pkg_a"), anchorNames(
+                file("a_body.pkb", "create or replace package body pkg_a\nas\n   null;\nend pkg_a;\n")));
+    }
+
+    @Test
+    public void theBodyKeywordIsReadInEitherCase() {
+        assertEquals(Arrays.asList("pkg_a"), anchorNames(file("a_body.pkb", BODY)));
+        assertEquals(Arrays.asList("pkg_a"), anchorNames(file("a_body.pkb", BODY.toLowerCase())));
+    }
+
+    /**
+     * A declaration head may be wrapped anywhere it has whitespace, the keyword included.
+     */
+    @Test
+    public void aNameOnTheLineAfterTheKeywordIsRead() {
+        assertEquals(Arrays.asList("pkg_a"), anchorNames(
+                file("a_body.pkb", "CREATE OR REPLACE PACKAGE BODY\n   pkg_a AS\n   NULL;\nEND pkg_a;\n")));
+    }
+
+    /**
+     * An unnamed anchor is worse than a wrongly named one: its dependency pattern is
+     * {@code \s*[.]+\S+}, which matches any dotted token, so one such declaration invents edges
+     * from most of the codebase. Runs of whitespace around the name must not produce one.
+     */
+    @Test
+    public void aRunOfSpacesDoesNotProduceAnUnnamedAnchor() {
+        assertEquals(Arrays.asList("pkg_a"), anchorNames(
+                file("a_body.pkb", "CREATE OR REPLACE PACKAGE BODY  pkg_a AS\n   NULL;\nEND pkg_a;\n")));
+        assertEquals(Arrays.asList("pkg_a"), anchorNames(
+                file("a_spec.pks", "CREATE OR REPLACE PACKAGE  pkg_a AS\n   NULL;\nEND pkg_a;\n")));
+    }
+
+    /**
+     * Only the keyword is skipped, not a name that begins with it: the token has to be BODY
+     * followed by whitespace, or a package called body_log would be anchored as "_log".
+     */
+    @Test
+    public void aPackageNamedAfterTheKeywordKeepsItsName() {
+        assertEquals(Arrays.asList("body_log"), anchorNames(
+                file("body_log.pks", "CREATE OR REPLACE PACKAGE body_log AS\n   PROCEDURE run;\nEND body_log;\n")));
+    }
+}


### PR DESCRIPTION
A package declaration is read by string search: find "PACKAGE ", then take everything up to the next space. For a body - CREATE OR REPLACE PACKAGE BODY debug_pkg - the token after PACKAGE is BODY, so the anchor is named BODY and not debug_pkg. Anchors are merged by name, so every file whose first PACKAGE keyword is a body declaration lands on one anchor called BODY, and the dependency graph grows a node that is not a package and collects the dependencies of every package body in the codebase.

A file that holds the spec before the body is unaffected, because the search finds the spec first. That is why the existing tests do not see this: their fixtures put spec and body in the same file. A codebase that keeps specs in .pks and bodies in .pkb, which is the ordinary Oracle layout, hits it on every body it has.

Measured over utPLSQL, alexandria-plsql-utils and oracle-db-examples, 311 PL/SQL files between them:

  before   102 edges, 18 of them out of a node called body
  after     84 edges, none fictitious

Eighteen edges removed, none added, no other edge altered. The real edges survive the removal because they are also carried by an anchor named after the file, and file names in these corpora match their package names. Where a file name does not match, the body's dependencies were attributed to body and are now attributed to the package. Edge instances move rather than disappear, 27 to 27 and 954 to 950, because a body that was a source under body is now a source under its own package, where an edge already existed.

The name is taken from after an optional BODY keyword, matched without regard to case and only as a whole token - BODY followed by whitespace - so that a package called body_log keeps its name.

The end of the name had to move with it. It was the next space, which never mattered while the scan stopped at the space after BODY; reading past BODY exposes it, because a declaration is as likely to read "package body ntlm_http_pkg" with the AS on the following line, and the name then ran on into the rest of the declaration. It now ends at the first whitespace. That also corrects a spec written the same way, which until now anchored under a name with a line break inside it.

Whitespace around the name is skipped rather than assumed to be a single space, for the same reason a declaration head wraps: the keyword and the name can sit on separate lines. Skipping it also closes a hazard that does not need this change to be reachable. "PACKAGE  pkg", with two spaces, yields an anchor whose name is the empty string and whose dependency pattern is \s*[.]+\S+ - which matches any dotted token in any file, so one such declaration invents edges across the whole codebase. A double space after BODY would have been a second route to it, new with this change; a double space after PACKAGE is the old one. Both are closed.

The string-search style is kept rather than replaced with a regex, so the change stays where the defect is.

PlSqlPackageBodyAnchorTest names its files differently from its packages, so that the anchor under test is the one taken from the declaration and not the one taken from the file name. Each part of the read is pinned on its own. Removing the BODY skip fails seven of its eight tests, and not skipping the whitespace after the keyword fails the same seven. Matching the keyword case-sensitively fails two. Ending the name at the first space instead of the first whitespace fails one. Letting BODY match as a prefix rather than a whole token fails one - the package called body_log, anchored as _log. Not skipping the whitespace before the name fails one - the double-spaced declaration, anchored under the empty string.