### PR TITLE
Scope a folder named plainly "mock" as test code

### DIFF
--- a/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/scoping/ScopingConventions.java
+++ b/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/scoping/ScopingConventions.java
@@ -510,8 +510,13 @@ public class ScopingConventions {
         testFilesConventions.add(new Convention(".*/test[-]helpers/.*", "", "Test helpers"));
         testFilesConventions.add(new Convention(".*/TestData/.*", "", "Test data"));
         testFilesConventions.add(new Convention(".*/mockapi/.*", "", "Mock resources"));
-        testFilesConventions.add(new Convention(".*/__mock[a-zA-Z0-9_\\- ]+/.*", "", "Mock resources"));
-        testFilesConventions.add(new Convention(".*/mock[a-zA-Z0-9_\\- ]+/.*", "", "Mock resources"));
+        // Any folder whose name starts with "mock" holds mock resources, so the rest of the name is
+        // matched with [^/]* rather than a list of allowed characters. The earlier [a-zA-Z0-9_\- ]+
+        // missed a folder named plainly "mock" (the + demanded at least one further character), one
+        // with a dot such as "mock.data", and one carrying any non-ASCII character. [^/] cannot cross
+        // a separator, so the match stays within the single folder name.
+        testFilesConventions.add(new Convention(".*/__mock[^/]*/.*", "", "Mock resources"));
+        testFilesConventions.add(new Convention(".*/mock[^/]*/.*", "", "Mock resources"));
         testFilesConventions.add(new Convention(".*_mock[.][a-zA-Z0-9_\\-]+", "", "Mock resources"));
 
         testFilesConventions.add(new Convention(".*[.]snap", "", "Jest snapshots"));

--- a/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/scoping/ScopingConventionsMockFoldersTest.java
+++ b/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/scoping/ScopingConventionsMockFoldersTest.java
@@ -1,0 +1,120 @@
+package nl.obren.sokrates.sourcecode.scoping;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression tests for the mock-folder test conventions.
+ *
+ * <p>Files under a folder whose name starts with {@code mock} are mock resources and belong in the
+ * <b>test</b> scope. The rules used to spell the rest of the folder name as
+ * {@code [a-zA-Z0-9_\- ]+}, which left three kinds of folder unmatched, so their files stayed in
+ * <b>main</b> and were counted as production code:
+ * <ul>
+ *   <li>a folder named plainly {@code mock} - the {@code +} demanded at least one further character;</li>
+ *   <li>a folder carrying a character outside that list, such as {@code mock.data};</li>
+ *   <li>a folder carrying any non-ASCII character, such as {@code mock-größe}.</li>
+ * </ul>
+ * The rest of the name is now {@code [^/]*}. These tests pin both that the newly covered folders are
+ * classified as test, and that the folders which already matched still do.
+ */
+class ScopingConventionsMockFoldersTest {
+
+    private final ScopingConventions conventions = new ScopingConventions();
+
+    private boolean matchesAny(List<Convention> rules, String path) {
+        return rules.stream().anyMatch(c -> c.pathMatches(path));
+    }
+
+    private void assertTestScope(String path) {
+        assertTrue(matchesAny(conventions.getTestFilesConventions(), path),
+                "expected TEST scope but was not classified there: " + path);
+    }
+
+    private void assertNotTestScope(String path) {
+        assertFalse(matchesAny(conventions.getTestFilesConventions(), path),
+                "expected NOT test scope but was classified as test: " + path);
+    }
+
+    // --- the folders the old character class missed ---------------------------------------------
+
+    @Test
+    void plainMockFolderIsTestScope() {
+        // The real case: elasticsearch keeps a test-service plugin under .../inference/mock/.
+        assertTestScope("/repo/x-pack/plugin/inference/qa/test-service-plugin/src/main/java/"
+                + "org/elasticsearch/xpack/inference/mock/TestInferenceServicePlugin.java");
+        assertTestScope("/repo/src/mock/M.java");
+        assertTestScope("../src/mock/M.java");
+        assertTestScope("/repo/src/mock/deep/nested/M.java");
+    }
+
+    @Test
+    void mockFolderWithPunctuationIsTestScope() {
+        assertTestScope("/repo/src/mock.data/M.java");
+        assertTestScope("/repo/src/mock+api/M.java");
+        assertTestScope("/repo/src/mock(old)/M.java");
+    }
+
+    @Test
+    void mockFolderWithNonAsciiNameIsTestScope() {
+        assertTestScope("/repo/src/mock-größe/M.java");
+        assertTestScope("/repo/src/mock-prøve/M.java");
+        assertTestScope("/repo/src/mock模拟/M.java");
+        assertTestScope("/repo/src/mockданные/M.java");
+    }
+
+    @Test
+    void doubleUnderscoreMockFolderVariantsAreTestScope() {
+        assertTestScope("/repo/src/__mock/M.java");
+        assertTestScope("/repo/src/__mock.data/M.java");
+        assertTestScope("/repo/src/__mock-größe/M.java");
+    }
+
+    // --- what already matched must keep matching -------------------------------------------------
+
+    @Test
+    void previouslyMatchingMockFoldersStillTestScope() {
+        assertTestScope("/repo/src/mocks/M.java");
+        assertTestScope("/repo/src/mockapi/M.java");
+        assertTestScope("/repo/src/mock-data/M.java");
+        assertTestScope("/repo/src/mock_data/M.java");
+        assertTestScope("/repo/src/mock data/M.java");
+        assertTestScope("/repo/src/mockStore/M.java");
+        assertTestScope("/repo/src/__mocks__/M.java");
+    }
+
+    @Test
+    void windowsStyleMockPathsAreTestScope() {
+        // pathMatches also tests the "\\"->"/" variant of the path; the rules must hold there too.
+        assertTestScope("C:\\repo\\src\\mock\\M.java");
+        assertTestScope("C:\\repo\\src\\mock-größe\\M.java");
+    }
+
+    // --- [^/] must not reach past the folder name ------------------------------------------------
+
+    @Test
+    void mockMustStartTheFolderName() {
+        assertNotTestScope("/repo/src/remock/M.java");
+        assertNotTestScope("/repo/src/notamock/M.java");
+        assertNotTestScope("/repo/src/demo/M.java");
+    }
+
+    @Test
+    void mockMustBeAFolderNotAFileName() {
+        // "mockery.java" is a file: there is no closing separator, so no folder rule applies.
+        assertNotTestScope("/repo/src/mockery.java");
+        assertNotTestScope("/repo/src/mock.java");
+    }
+
+    @Test
+    void aRelativeRootIsNotItselfAMockFolder() {
+        // The default srcRoot is "..", so every path carries a leading "..". A rule anchored on
+        // [^/] must not turn that into a match for an ordinary source file.
+        assertNotTestScope("../src/main/java/App.java");
+        assertNotTestScope("../README.md");
+    }
+}


### PR DESCRIPTION
Test-support code that lives in a folder named plainly `mock` is currently counted as **production
code**. In elasticsearch, for example:

    x-pack/plugin/inference/qa/test-service-plugin/src/main/java/
        org/elasticsearch/xpack/inference/mock/

7 files, 2,482 lines, every one named `Test*` — all of it in the **main** scope today. Scope drives
main lines of code, duplication, the risk distributions and the landscape roll-up, so the whole
chain is off by those lines with nothing to indicate it.

Rename that folder `mocks` and it is scoped as test correctly. The singular is what misses.

## Cause

The two mock-folder rules in `ScopingConventions` spell the rest of the folder name as
`[a-zA-Z0-9_\- ]+`:

```java
testFilesConventions.add(new Convention(".*/__mock[a-zA-Z0-9_\\- ]+/.*", "", "Mock resources"));
testFilesConventions.add(new Convention(".*/mock[a-zA-Z0-9_\\- ]+/.*", "", "Mock resources"));
```

That leaves three kinds of folder unmatched:

| folder | why it misses |
|---|---|
| `mock/` | the `+` demands at least one further character |
| `mock.data/` | `.` is outside the class |
| `mock-größe/` | any non-ASCII character is outside the class |

Nothing else catches them either — not `/[Tt]est/`, `/[Tt]ests/`, `-test-` or `_test.`, and nothing
matches the leading `Test` in a file name.

The first row is the one that occurs in practice; I found it by scanning real code rather than by
reading the regex (details under *How this was checked*).

## Change

```java
testFilesConventions.add(new Convention(".*/__mock[^/]*/.*", "", "Mock resources"));
testFilesConventions.add(new Convention(".*/mock[^/]*/.*", "", "Mock resources"));
```

Two lines, plus a comment naming what the old class missed. `[^X]*` is the negated-class idiom
already used 11 times in this same file (`.*/angular([^.]*)\.js`, `.*/yui([^.]*)\.js`, …), so it
should not read as a foreign style.

## It also removes a latent PatternSyntaxException

Worth calling out separately, because it is not obvious from the diff.

The old class contains an escaped hyphen, so the pattern string contains a backslash.
`SourceFileFilter.pathMatches` has a final branch that fires **only for a pattern containing a
backslash**: it rewrites `\` to `/` and retries. On these two patterns that rewrite produces

    .*/mock[a-zA-Z0-9_/- ]+/.*

`[_/- ]` is an illegal character range — `/` is 0x2F, space is 0x20 — so `Pattern.compile` throws.
`RegexUtils.matchesEntirely` catches it and returns false, and `getCompiledPattern` never caches a
pattern that threw. The exception was therefore constructed and thrown **once per path** for every
path reaching that branch, which is every non-matching path.

`[^/]*` contains no backslash, so the branch never fires. Matching these two rules over 64,221 real
paths drops from ~151 ms to ~59 ms; the full 59-rule test-convention set drops about 3.5%.

## How this was checked

**Strict widening, verified rather than argued.** Every character in the old class is a non-`/` and
`+` ⊆ `*`, so the new pattern must be a superset. I ran both over **64,921 paths** — 64,221 real
ones (elasticsearch, flask, pandas, postgres, redis, plus 45 further repositories) and 700 generated
ones injecting every printable ASCII character and a spread of Latin-1, CJK, Cyrillic and Greek into
a mock segment:

    mock    old=229  new=386   paths that lost their match: 0
    __mock  old=65   new=115   paths that lost their match: 0

Negative cases hold — `remock/`, `notamock/`, `mockery.java` and `foo/bar/` stay unmatched; `mock`
must still start a folder name.

**End to end**, `init` + `generateReports`, reading `aspect_*.txt` out of `data.zip`:

    before   main: App.java, mock, mock.data, mock-größe, mock-prøve
    after    main: App.java

**Tests.** New `ScopingConventionsMockFoldersTest`, 9 tests, a sibling to the existing
`ScopingConventionsHiddenFilesTest` and written in its style. Each was mutation-checked — reverting
either rule to the old class, `[^/]*` → `[^/]+`, and dropping the leading `/` anchor each fail the
suite, and the baseline is green after restoring. Full build: 722 tests, 0 failures.

---

## NOTE — a redundancy I deliberately did not touch

`.*/mockapi/.*`, two lines above, is now **fully redundant**: `.*/mock[^/]*/.*` subsumes it. I left
it in place rather than tidy your list as a side effect of a bug fix.

## QUESTION — should it come out?

Happy to drop `.*/mockapi/.*` in this PR or leave it; your call. Related, and equally your call:
`mock` matching is currently case-sensitive, so `Mock-Test/` (ordinary C# and Java naming) is still
scoped as main, while `[Mm]ocks` is case-tolerant. Making the mock rules case-insensitive would fix
that, but it could move a noticeable volume of code from main to test in existing analyses, so it
did not belong in this change. Say the word and I will raise it separately with before/after numbers.

## NOTE — on the non-ASCII row

`mock-größe/` is fixed here as a side effect, not as the motivation. I looked for it specifically and
could not find a single instance: zero non-ASCII source directory names in 52,751 directories
scanned (including a German and a Danish company's repositories), and a GitHub path search turned up
only documentation files. The bare `mock/` case is the one with real evidence behind it, so that is
what the PR leads with.
