### PR TITLE
Bound the memory duplication analysis needs on a clone-dense repository

### DIFF
--- a/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/analysis/files/DuplicationAnalyzer.java
+++ b/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/analysis/files/DuplicationAnalyzer.java
@@ -180,13 +180,16 @@ public class DuplicationAnalyzer extends Analyzer {
                     fileIds.put(path, id);
                 }
                 ids[i] = id;
-                // Blocks sharing a file and a cleaned start line are interchangeable: every other field is
-                // a function of those two plus the block size, which addFileToDuplicationInstance derives
-                // from the same values. Keeping the first mirrors merge()'s first-writer-wins.
+                // Two blocks sharing a file and a cleaned start line are interchangeable, so the first one
+                // seen can stand for all of them: addFileToDuplicationInstance derives every other field
+                // from the file, the cleaned start line and the block size, and the block size is the same
+                // for every block in a run (Blocks.optimize is fixed true, which pins the engine to
+                // minDuplicationBlockLoc). Should variable block sizes ever be reintroduced, this key would
+                // have to carry the size as well.
                 blockByFileAndStart.putIfAbsent(pack(id, block.getCleanedStartLine()), block);
             }
-            // merge() emits both orderings of every pair and lets the normalised key discard one of them;
-            // emitting only i<j and normalising here reaches the same set at half the writes.
+            // A pair is unordered, so each unordered pair is emitted once (j > i) and put in canonical
+            // order here, rather than emitting both orderings and discarding one of them later.
             for (int i = 0; i < count; i++) {
                 for (int j = i + 1; j < count; j++) {
                     DuplicatedFileBlock block1 = blocks.get(i);
@@ -262,9 +265,12 @@ public class DuplicationAnalyzer extends Analyzer {
         return Arrays.binarySearch(sorted, value) >= 0;
     }
 
-    // A growable long array. The whole point of the bucketing is that a pair costs 8 bytes here instead
-    // of the ~313-byte object graph merge() builds for it, so boxing them into a List<Long> would give
-    // most of the memory straight back.
+    // A growable long array: a pair is two ints, so it needs no object of its own. Boxing pairs into a
+    // List<Long> would give most of the saving straight back, and the saving is the point - the previous
+    // implementation spent roughly 300 bytes per pair on an instance, two copied blocks, a composite
+    // string key and a map node. Here a pair costs one array slot wherever a bucket holds more than a
+    // handful; a bucket with a single pair still carries its own map entry and array header, so the win
+    // is largest exactly where the old cost was worst.
     private static final class LongArray {
         private long[] values = new long[8];
         private int size = 0;

--- a/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/analysis/files/DuplicationAnalyzer.java
+++ b/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/analysis/files/DuplicationAnalyzer.java
@@ -163,7 +163,8 @@ public class DuplicationAnalyzer extends Analyzer {
      * the global map is not needed. This groups the pairs by file pair, keeping each one as a packed long
      * rather than an object graph, and walks the chains inside each bucket.
      */
-    private List<DuplicationInstance> mergeAndConsolidatePerFilePair(List<DuplicationInstance> duplicates) {
+    // Package-private for testing (same as getPairKey).
+    List<DuplicationInstance> mergeAndConsolidatePerFilePair(List<DuplicationInstance> duplicates) {
         Map<String, Integer> fileIds = new HashMap<>();
         Map<Long, DuplicatedFileBlock> blockByFileAndStart = new HashMap<>();
         Map<Long, LongArray> buckets = new HashMap<>();
@@ -290,7 +291,8 @@ public class DuplicationAnalyzer extends Analyzer {
         }
     }
 
-    private Map<String, DuplicationInstance> consolidate(Map<String, DuplicationInstance> merged) {
+    // Package-private for testing (same as getPairKey).
+    Map<String, DuplicationInstance> consolidate(Map<String, DuplicationInstance> merged) {
         Map<String, DuplicationInstance> mergedConsolidated = new HashMap<>(merged);
         merged.keySet().forEach(key -> {
             if (!mergedConsolidated.containsKey(key)) {
@@ -329,7 +331,8 @@ public class DuplicationAnalyzer extends Analyzer {
         return mergedConsolidated;
     }
 
-    private Map<String, DuplicationInstance> merge(List<DuplicationInstance> duplicates) {
+    // Package-private for testing (same as getPairKey).
+    Map<String, DuplicationInstance> merge(List<DuplicationInstance> duplicates) {
         Map<String, DuplicationInstance> merged = new HashMap<>();
         duplicates.forEach(d -> {
             d.getDuplicatedFileBlocks().forEach(file1 -> {

--- a/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/analysis/files/DuplicationAnalyzer.java
+++ b/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/analysis/files/DuplicationAnalyzer.java
@@ -61,9 +61,8 @@ public class DuplicationAnalyzer extends Analyzer {
 
 
         ProcessingStopwatch.start("analysis/duplication/consolidating duplicates");
-        ArrayList<DuplicationInstance> consolidatedDuplicationInstances = BUCKETED
-                ? new ArrayList<>(mergeAndConsolidatePerFilePair(duplicates))
-                : new ArrayList<>(consolidate(merge(duplicates)).values());
+        ArrayList<DuplicationInstance> consolidatedDuplicationInstances =
+                new ArrayList<>(mergeAndConsolidatePerFilePair(duplicates));
         consolidatedDuplicationInstances.sort((a, b) -> b.getBlockSize() - a.getBlockSize());
         duplcationAnalysisResults.setAllDuplicates(consolidatedDuplicationInstances);
         ProcessingStopwatch.end("analysis/duplication/consolidating duplicates");
@@ -104,7 +103,7 @@ public class DuplicationAnalyzer extends Analyzer {
         }
     }
 
-    // Package-private for testing (same as getPairKey).
+    // Package-private for testing.
     void addMostFrequentDuplicates(List<DuplicationInstance> duplicates) {
         // Sort a copy by descending number of duplicated file blocks, then read from that sorted copy.
         // (Previously the sort was applied to a throwaway list and the unsorted original was iterated, so
@@ -148,22 +147,21 @@ public class DuplicationAnalyzer extends Analyzer {
         });
     }
 
-    // PROTOTYPE (SOK-dwflvoyo): -Dsokrates.duplication.bucketed=true selects the per-file-pair
-    // implementation below instead of merge()+consolidate(). One jar, two code paths, so a baseline and
-    // a prototype measurement cannot differ by build provenance.
-    private static final boolean BUCKETED = "true".equals(System.getProperty("sokrates.duplication.bucketed"));
-
     /**
-     * Behaviour-preserving replacement for {@link #consolidate}({@link #merge}(...)).
+     * Collapses the duplicated block pairs the engine found into one instance per run of adjacent pairs.
      *
-     * merge() materialises one DuplicationInstance (plus two copied blocks and an ~89-byte composite
-     * String key) for every ordered pair of blocks inside every instance, then consolidate() collapses
-     * runs of adjacent pairs back into single instances. Every chain consolidate() walks is local to one
-     * unordered file pair - getPairKey holds the two paths fixed and only advances the start lines - so
-     * the global map is not needed. This groups the pairs by file pair, keeping each one as a packed long
-     * rather than an object graph, and walks the chains inside each bucket.
+     * A pair is two blocks of the same duplicated code in two places. Runs matter because the engine emits
+     * one instance per sliding window of minDuplicationBlockLoc lines, so a long clone arrives as a chain
+     * of windows starting one line apart and has to be put back together.
+     *
+     * Every such chain is local to one unordered file pair: the two paths are fixed and only the start
+     * lines advance. So the pairs are grouped by file pair and each is held as a packed long - the two
+     * cleaned start lines - rather than as an object graph, and the chains are walked inside each bucket.
+     * The previous implementation instead built one instance, two copied blocks and a composite string key
+     * for every pair in a single global map, which on a clone-dense repository reached millions of entries
+     * and several GB before collapsing back to a fraction of that.
      */
-    // Package-private for testing (same as getPairKey).
+    // Package-private for testing.
     List<DuplicationInstance> mergeAndConsolidatePerFilePair(List<DuplicationInstance> duplicates) {
         Map<String, Integer> fileIds = new HashMap<>();
         Map<Long, DuplicatedFileBlock> blockByFileAndStart = new HashMap<>();
@@ -249,8 +247,8 @@ public class DuplicationAnalyzer extends Analyzer {
         return instance;
     }
 
-    // The ordering getPairKey applies: by relative path, and for two blocks in the same file by cleaned
-    // start line. Kept as one predicate so the two implementations cannot drift apart.
+    // A pair is unordered, so it needs one canonical order: by relative path, and for two blocks in the
+    // same file by cleaned start line.
     private boolean inPairKeyOrder(DuplicatedFileBlock block1, DuplicatedFileBlock block2) {
         int comparison = block1.getSourceFile().getRelativePath().compareTo(block2.getSourceFile().getRelativePath());
         return comparison < 0 || (comparison == 0 && block1.getCleanedStartLine() < block2.getCleanedStartLine());
@@ -291,75 +289,6 @@ public class DuplicationAnalyzer extends Analyzer {
         }
     }
 
-    // Package-private for testing (same as getPairKey).
-    Map<String, DuplicationInstance> consolidate(Map<String, DuplicationInstance> merged) {
-        Map<String, DuplicationInstance> mergedConsolidated = new HashMap<>(merged);
-        merged.keySet().forEach(key -> {
-            if (!mergedConsolidated.containsKey(key)) {
-                return;
-            }
-            DuplicationInstance currentInstance = mergedConsolidated.get(key);
-            DuplicatedFileBlock file1 = currentInstance.getDuplicatedFileBlocks().get(0);
-            DuplicatedFileBlock file2 = currentInstance.getDuplicatedFileBlocks().get(1);
-            int offset = 1;
-            while (true) {
-                String nextKey = getPairKey(file1, file2, offset);
-                DuplicationInstance nextInstance = mergedConsolidated.get(nextKey);
-                if (nextInstance != null) {
-                    DuplicatedFileBlock nextBlock1 = nextInstance.getDuplicatedFileBlocks().get(0);
-                    DuplicatedFileBlock nextBlock2 = nextInstance.getDuplicatedFileBlocks().get(1);
-                    if (!nextBlock1.getSourceFile().getRelativePath().equals(file1.getSourceFile().getRelativePath())) {
-                        DuplicatedFileBlock temp = nextBlock1;
-                        nextBlock1 = nextBlock2;
-                        nextBlock2 = temp;
-                    }
-
-                    file1.setEndLine(nextBlock1.getEndLine());
-                    file1.setCleanedEndLine(nextBlock1.getCleanedEndLine());
-
-                    file2.setEndLine(nextBlock2.getEndLine());
-                    file2.setCleanedEndLine(nextBlock2.getCleanedEndLine());
-
-                    mergedConsolidated.remove(nextKey);
-                    currentInstance.setBlockSize(file1.getCleanedEndLine() - file1.getCleanedStartLine() + 1);
-                    offset += 1;
-                } else {
-                    break;
-                }
-            }
-        });
-        return mergedConsolidated;
-    }
-
-    // Package-private for testing (same as getPairKey).
-    Map<String, DuplicationInstance> merge(List<DuplicationInstance> duplicates) {
-        Map<String, DuplicationInstance> merged = new HashMap<>();
-        duplicates.forEach(d -> {
-            d.getDuplicatedFileBlocks().forEach(file1 -> {
-                d.getDuplicatedFileBlocks().stream()
-                        .filter(file2 -> !(file1 == file2 && file1.getStartLine() == file2.getStartLine()))
-                        .forEach(file2 -> {
-                            String key = getPairKey(file1, file2, 0);
-                            if (!merged.containsKey(key)) {
-                                DuplicationInstance duplicationInstance = new DuplicationInstance();
-                                String path1 = file1.getSourceFile().getRelativePath();
-                                String path2 = file2.getSourceFile().getRelativePath();
-                                if (path1.compareTo(path2) <= 0) {
-                                    duplicationInstance.getDuplicatedFileBlocks().add(copyOf(file1));
-                                    duplicationInstance.getDuplicatedFileBlocks().add(copyOf(file2));
-                                } else {
-                                    duplicationInstance.getDuplicatedFileBlocks().add(copyOf(file2));
-                                    duplicationInstance.getDuplicatedFileBlocks().add(copyOf(file1));
-                                }
-                                duplicationInstance.setBlockSize(d.getBlockSize());
-                                merged.put(key, duplicationInstance);
-                            }
-                        });
-            });
-        });
-        return merged;
-    }
-
     private DuplicatedFileBlock copyOf(DuplicatedFileBlock block) {
         DuplicatedFileBlock newBlock = new DuplicatedFileBlock();
         newBlock.setStartLine(block.getStartLine());
@@ -369,34 +298,6 @@ public class DuplicationAnalyzer extends Analyzer {
         newBlock.setSourceFile(block.getSourceFile());
         newBlock.setSourceFileCleanedLinesOfCode(block.getSourceFileCleanedLinesOfCode());
         return newBlock;
-    }
-
-    public String getPairKey(DuplicatedFileBlock block1, DuplicatedFileBlock block2, int offset) {
-        String relPath1 = block1.getSourceFile().getRelativePath();
-        String relPath2 = block2.getSourceFile().getRelativePath();
-        DuplicatedFileBlock file1;
-        DuplicatedFileBlock file2;
-        String path1;
-        String path2;
-
-        if (relPath1.compareTo(relPath2) < 0) {
-            file1 = block1;
-            file2 = block2;
-            path1 = relPath1;
-            path2 = relPath2;
-        } else if (relPath1.compareTo(relPath2) == 0 && block1.getCleanedStartLine() < block2.getCleanedStartLine()) {
-            file1 = block1;
-            file2 = block2;
-            path1 = relPath1;
-            path2 = relPath2;
-        } else {
-            file1 = block2;
-            file2 = block1;
-            path1 = relPath2;
-            path2 = relPath1;
-        }
-
-        return path1 + ":" + (file1.getCleanedStartLine() + offset) + "::" + path2 + ":" + (file2.getCleanedStartLine() + offset) + "";
     }
 
     private boolean skipDuplicationAnalysis() {

--- a/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/analysis/files/DuplicationAnalyzer.java
+++ b/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/analysis/files/DuplicationAnalyzer.java
@@ -61,8 +61,9 @@ public class DuplicationAnalyzer extends Analyzer {
 
 
         ProcessingStopwatch.start("analysis/duplication/consolidating duplicates");
-        Map<String, DuplicationInstance> mergedConsolidated = consolidate(merge(duplicates));
-        ArrayList<DuplicationInstance> consolidatedDuplicationInstances = new ArrayList<>(mergedConsolidated.values());
+        ArrayList<DuplicationInstance> consolidatedDuplicationInstances = BUCKETED
+                ? new ArrayList<>(mergeAndConsolidatePerFilePair(duplicates))
+                : new ArrayList<>(consolidate(merge(duplicates)).values());
         consolidatedDuplicationInstances.sort((a, b) -> b.getBlockSize() - a.getBlockSize());
         duplcationAnalysisResults.setAllDuplicates(consolidatedDuplicationInstances);
         ProcessingStopwatch.end("analysis/duplication/consolidating duplicates");
@@ -71,7 +72,7 @@ public class DuplicationAnalyzer extends Analyzer {
         // Aggregated once and reused below (both the file count and the per-component/per-extension
         // aggregation need it); it used to be computed twice.
         List<SourceFileDuplication> duplicationPerSourceFile = DuplicationAggregator.getDuplicationPerSourceFile(duplicates);
-        int numberOfDuplicates = mergedConsolidated.size();
+        int numberOfDuplicates = consolidatedDuplicationInstances.size();
         int numberOfDuplicatedLines = DuplicationUtils.getNumberOfDuplicatedLines(duplicates);
         int totalNumberOfCleanedLines = DuplicationUtils.getTotalNumberOfCleanedLines(main.getSourceFiles());
         int numberOfFilesWithDuplicates = duplicationPerSourceFile.size();
@@ -92,11 +93,11 @@ public class DuplicationAnalyzer extends Analyzer {
         addMetricsAndSummary(progressFeedback, duplicationPerSourceFile);
 
         addMostFrequentDuplicates(duplicates);
-        addLongestDuplicates(mergedConsolidated);
+        addLongestDuplicates(consolidatedDuplicationInstances);
     }
 
-    private void addLongestDuplicates(Map<String, DuplicationInstance> mergedConsolidated) {
-        List<DuplicationInstance> filePairs = new ArrayList<>(mergedConsolidated.values());
+    private void addLongestDuplicates(List<DuplicationInstance> mergedConsolidated) {
+        List<DuplicationInstance> filePairs = new ArrayList<>(mergedConsolidated);
         Collections.sort(filePairs, (o1, o2) -> -Integer.valueOf(o1.getBlockSize()).compareTo(o2.getBlockSize()));
         for (int i = 0; i < Math.min(codeConfiguration.getAnalysis().getMaxTopListSize(), filePairs.size()); i++) {
             duplcationAnalysisResults.getLongestDuplicates().add(filePairs.get(i));
@@ -145,6 +146,148 @@ public class DuplicationAnalyzer extends Analyzer {
                         addComponentDuplicationMetrics(logicalDecomposition, componentDuplication, displayName);
                     });
         });
+    }
+
+    // PROTOTYPE (SOK-dwflvoyo): -Dsokrates.duplication.bucketed=true selects the per-file-pair
+    // implementation below instead of merge()+consolidate(). One jar, two code paths, so a baseline and
+    // a prototype measurement cannot differ by build provenance.
+    private static final boolean BUCKETED = "true".equals(System.getProperty("sokrates.duplication.bucketed"));
+
+    /**
+     * Behaviour-preserving replacement for {@link #consolidate}({@link #merge}(...)).
+     *
+     * merge() materialises one DuplicationInstance (plus two copied blocks and an ~89-byte composite
+     * String key) for every ordered pair of blocks inside every instance, then consolidate() collapses
+     * runs of adjacent pairs back into single instances. Every chain consolidate() walks is local to one
+     * unordered file pair - getPairKey holds the two paths fixed and only advances the start lines - so
+     * the global map is not needed. This groups the pairs by file pair, keeping each one as a packed long
+     * rather than an object graph, and walks the chains inside each bucket.
+     */
+    private List<DuplicationInstance> mergeAndConsolidatePerFilePair(List<DuplicationInstance> duplicates) {
+        Map<String, Integer> fileIds = new HashMap<>();
+        Map<Long, DuplicatedFileBlock> blockByFileAndStart = new HashMap<>();
+        Map<Long, LongArray> buckets = new HashMap<>();
+
+        for (DuplicationInstance instance : duplicates) {
+            List<DuplicatedFileBlock> blocks = instance.getDuplicatedFileBlocks();
+            int count = blocks.size();
+            int[] ids = new int[count];
+            for (int i = 0; i < count; i++) {
+                DuplicatedFileBlock block = blocks.get(i);
+                String path = block.getSourceFile().getRelativePath();
+                Integer id = fileIds.get(path);
+                if (id == null) {
+                    id = fileIds.size();
+                    fileIds.put(path, id);
+                }
+                ids[i] = id;
+                // Blocks sharing a file and a cleaned start line are interchangeable: every other field is
+                // a function of those two plus the block size, which addFileToDuplicationInstance derives
+                // from the same values. Keeping the first mirrors merge()'s first-writer-wins.
+                blockByFileAndStart.putIfAbsent(pack(id, block.getCleanedStartLine()), block);
+            }
+            // merge() emits both orderings of every pair and lets the normalised key discard one of them;
+            // emitting only i<j and normalising here reaches the same set at half the writes.
+            for (int i = 0; i < count; i++) {
+                for (int j = i + 1; j < count; j++) {
+                    DuplicatedFileBlock block1 = blocks.get(i);
+                    DuplicatedFileBlock block2 = blocks.get(j);
+                    boolean inOrder = inPairKeyOrder(block1, block2);
+                    DuplicatedFileBlock first = inOrder ? block1 : block2;
+                    DuplicatedFileBlock second = inOrder ? block2 : block1;
+                    long bucketKey = pack(inOrder ? ids[i] : ids[j], inOrder ? ids[j] : ids[i]);
+                    long entry = pack(first.getCleanedStartLine(), second.getCleanedStartLine());
+                    LongArray bucket = buckets.get(bucketKey);
+                    if (bucket == null) {
+                        bucket = new LongArray();
+                        buckets.put(bucketKey, bucket);
+                    }
+                    bucket.add(entry);
+                }
+            }
+        }
+
+        List<DuplicationInstance> result = new ArrayList<>();
+        for (Map.Entry<Long, LongArray> bucketEntry : buckets.entrySet()) {
+            int fileA = (int) (bucketEntry.getKey() >>> 32);
+            int fileB = (int) (long) bucketEntry.getKey();
+            long[] entries = bucketEntry.getValue().sortedDistinct();
+            for (long entry : entries) {
+                int startA = (int) (entry >>> 32);
+                int startB = (int) entry;
+                // consolidate() absorbs forward from every surviving key, so a key starts a chain exactly
+                // when its predecessor (both start lines one lower) is absent.
+                if (contains(entries, pack(startA - 1, startB - 1))) {
+                    continue;
+                }
+                int length = 1;
+                while (contains(entries, pack(startA + length, startB + length))) {
+                    length++;
+                }
+                result.add(chainInstance(blockByFileAndStart, fileA, fileB, startA, startB, length));
+            }
+        }
+        return result;
+    }
+
+    private DuplicationInstance chainInstance(Map<Long, DuplicatedFileBlock> blockByFileAndStart,
+                                              int fileA, int fileB, int startA, int startB, int length) {
+        DuplicatedFileBlock blockA = copyOf(blockByFileAndStart.get(pack(fileA, startA)));
+        DuplicatedFileBlock blockB = copyOf(blockByFileAndStart.get(pack(fileB, startB)));
+        DuplicatedFileBlock lastA = blockByFileAndStart.get(pack(fileA, startA + length - 1));
+        DuplicatedFileBlock lastB = blockByFileAndStart.get(pack(fileB, startB + length - 1));
+        blockA.setEndLine(lastA.getEndLine());
+        blockA.setCleanedEndLine(lastA.getCleanedEndLine());
+        blockB.setEndLine(lastB.getEndLine());
+        blockB.setCleanedEndLine(lastB.getCleanedEndLine());
+
+        DuplicationInstance instance = new DuplicationInstance();
+        instance.getDuplicatedFileBlocks().add(blockA);
+        instance.getDuplicatedFileBlocks().add(blockB);
+        instance.setBlockSize(blockA.getCleanedEndLine() - blockA.getCleanedStartLine() + 1);
+        return instance;
+    }
+
+    // The ordering getPairKey applies: by relative path, and for two blocks in the same file by cleaned
+    // start line. Kept as one predicate so the two implementations cannot drift apart.
+    private boolean inPairKeyOrder(DuplicatedFileBlock block1, DuplicatedFileBlock block2) {
+        int comparison = block1.getSourceFile().getRelativePath().compareTo(block2.getSourceFile().getRelativePath());
+        return comparison < 0 || (comparison == 0 && block1.getCleanedStartLine() < block2.getCleanedStartLine());
+    }
+
+    private static long pack(int high, int low) {
+        return (((long) high) << 32) | (low & 0xffffffffL);
+    }
+
+    private static boolean contains(long[] sorted, long value) {
+        return Arrays.binarySearch(sorted, value) >= 0;
+    }
+
+    // A growable long array. The whole point of the bucketing is that a pair costs 8 bytes here instead
+    // of the ~313-byte object graph merge() builds for it, so boxing them into a List<Long> would give
+    // most of the memory straight back.
+    private static final class LongArray {
+        private long[] values = new long[8];
+        private int size = 0;
+
+        void add(long value) {
+            if (size == values.length) {
+                values = Arrays.copyOf(values, values.length * 2);
+            }
+            values[size++] = value;
+        }
+
+        long[] sortedDistinct() {
+            long[] sorted = Arrays.copyOf(values, size);
+            Arrays.sort(sorted);
+            int distinct = 0;
+            for (int i = 0; i < sorted.length; i++) {
+                if (i == 0 || sorted[i] != sorted[i - 1]) {
+                    sorted[distinct++] = sorted[i];
+                }
+            }
+            return distinct == sorted.length ? sorted : Arrays.copyOf(sorted, distinct);
+        }
     }
 
     private Map<String, DuplicationInstance> consolidate(Map<String, DuplicationInstance> merged) {

--- a/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/analysis/files/DuplicationAnalyzerTest.java
+++ b/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/analysis/files/DuplicationAnalyzerTest.java
@@ -56,46 +56,4 @@ class DuplicationAnalyzerTest {
         assertEquals(3, mostFrequent.get(2).getDuplicatedFileBlocks().size());
     }
 
-    @Test
-    void getPairKey() {
-        CodeAnalysisResults analysisResults = new CodeAnalysisResults();
-        analysisResults.setCodeConfiguration(new CodeConfiguration());
-        DuplicationAnalyzer analyzer = new DuplicationAnalyzer(analysisResults);
-
-        DuplicatedFileBlock block1 = new DuplicatedFileBlock();
-        DuplicatedFileBlock block2 = new DuplicatedFileBlock();
-        DuplicatedFileBlock block1b = new DuplicatedFileBlock();
-
-        SourceFile sourceFile1 = new SourceFile(new File("path1.txt"));
-        sourceFile1.setRelativePath("path1.txt");
-        block1.setSourceFile(sourceFile1);
-        block1.setStartLine(1);
-        block1.setCleanedStartLine(1);
-
-        SourceFile sourceFile2 = new SourceFile(new File("path2.txt"));
-        sourceFile2.setRelativePath("path2.txt");
-        block2.setSourceFile(sourceFile2);
-        block2.setStartLine(11);
-        block2.setCleanedStartLine(11);
-
-        SourceFile sourceFile1b = new SourceFile(new File("path1.txt"));
-        sourceFile1b.setRelativePath("path1.txt");
-        block1b.setSourceFile(sourceFile1b);
-        block1b.setStartLine(20);
-        block1b.setCleanedStartLine(20);
-
-        assertEquals(analyzer.getPairKey(block1, block2, 0), "path1.txt:1::path2.txt:11");
-        assertEquals(analyzer.getPairKey(block1, block2, 1), "path1.txt:2::path2.txt:12");
-        assertEquals(analyzer.getPairKey(block1, block2, 10), "path1.txt:11::path2.txt:21");
-
-        assertEquals(analyzer.getPairKey(block2, block1, 0), "path1.txt:1::path2.txt:11");
-        assertEquals(analyzer.getPairKey(block2, block1, 1), "path1.txt:2::path2.txt:12");
-        assertEquals(analyzer.getPairKey(block2, block1, 10), "path1.txt:11::path2.txt:21");
-
-        assertEquals(analyzer.getPairKey(block1, block1b, 0), "path1.txt:1::path1.txt:20");
-        assertEquals(analyzer.getPairKey(block1, block1b, 10), "path1.txt:11::path1.txt:30");
-
-        assertEquals(analyzer.getPairKey(block1b, block1, 0), "path1.txt:1::path1.txt:20");
-        assertEquals(analyzer.getPairKey(block1b, block1, 10), "path1.txt:11::path1.txt:30");
-    }
 }

--- a/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/analysis/files/DuplicationPerFilePairConsolidationTest.java
+++ b/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/analysis/files/DuplicationPerFilePairConsolidationTest.java
@@ -65,7 +65,6 @@ class DuplicationPerFilePairConsolidationTest {
             instance.getDuplicatedFileBlocks().forEach(block -> blocks.add(
                     block.getSourceFile().getRelativePath() + "|" + block.getStartLine() + "-" + block.getEndLine()
                             + "|" + block.getCleanedStartLine() + "-" + block.getCleanedEndLine()));
-            Collections.sort(blocks);
             signatures.add(instance.getBlockSize() + "#" + String.join("~", blocks));
         });
         Collections.sort(signatures);
@@ -93,6 +92,9 @@ class DuplicationPerFilePairConsolidationTest {
         assertEquals(30, first.getEndLine());
         assertEquals(20, second.getCleanedStartLine());
         assertEquals(25, second.getCleanedEndLine());
+        // Carried through the copy: duplication exports report a block's share of its file.
+        assertEquals(1000, first.getSourceFileCleanedLinesOfCode());
+        assertEquals(1000, second.getSourceFileCleanedLinesOfCode());
     }
 
     @Test
@@ -208,6 +210,33 @@ class DuplicationPerFilePairConsolidationTest {
         assertEquals(BLOCK, result.get(0).getBlockSize());
     }
 
+    @Test
+    void reproducesTheOutputOfTheMapBasedImplementation() throws Exception {
+        // Golden values recorded from the previous merge()+consolidate() implementation over this corpus,
+        // before it was removed. They are what makes this a behaviour-preserving change rather than a
+        // plausible rewrite, so they must not be re-recorded from the current code to make a failure pass.
+        // signatures() keeps each instance's blocks in their own order, so these pin the order too.
+        List<String> signatures = signatures(analyzer().mergeAndConsolidatePerFilePair(pseudoRandomCorpus()));
+
+        assertEquals(577, signatures.size());
+        assertEquals("6#f0.java|10-20|5-10~f5.java|44-54|22-27", signatures.get(0));
+        assertEquals("8#f2.java|46-60|23-30~f5.java|48-62|24-31", signatures.get(signatures.size() - 1));
+        assertEquals("eb336aef38c2c16b0d1ccc6f7967fbb4f5a23f921e372f5ac0e872a4d0db8db2", sha256(signatures));
+    }
+
+    @Test
+    void reproducesTheOutputOfTheMapBasedImplementationForPairsInsideOneFile() throws Exception {
+        // Pairs inside one file are the shape where the two implementations could order an instance's two
+        // blocks differently, and the corpus above holds only 70 of them. These golden values come from the
+        // same recording of the previous implementation over a corpus that is 381 of them.
+        List<String> signatures = signatures(analyzer().mergeAndConsolidatePerFilePair(sameFileCorpus()));
+
+        assertEquals(466, signatures.size());
+        assertEquals("6#other0.java|14-24|7-12~s0.java|14-24|7-12", signatures.get(0));
+        assertEquals("9#s1.java|12-28|6-14~s1.java|26-42|13-21", signatures.get(signatures.size() - 1));
+        assertEquals("21fb055570926e8b44f5c3bf31324cde698f369729916ecc2436e6d27422de91", sha256(signatures));
+    }
+
     // Deterministic pseudo-random corpus: overlapping runs, shared blocks, intra-file pairs and repeats,
     // so agreement over it is agreement over the shapes the engine actually emits.
     List<DuplicationInstance> pseudoRandomCorpus() {
@@ -225,28 +254,55 @@ class DuplicationPerFilePairConsolidationTest {
             if (state % 3 == 0) {
                 blocks.add(block("f" + ((fileA + 3) % 7) + ".java", startA + 1, BLOCK));
             }
+            sortAsTheEngineWould(blocks);
             duplicates.add(instance(BLOCK, blocks.toArray(new DuplicatedFileBlock[0])));
         }
         return duplicates;
     }
 
-    @Test
-    void reproducesTheOutputOfTheMapBasedImplementation() throws Exception {
-        // Golden values recorded from the previous merge()+consolidate() implementation over this corpus,
-        // before it was removed. They are what makes this a behaviour-preserving change rather than a
-        // plausible rewrite, so they must not be re-recorded from the current code to make a failure pass.
-        List<String> signatures = signatures(analyzer().mergeAndConsolidatePerFilePair(pseudoRandomCorpus()));
 
-        assertEquals(577, signatures.size());
-        assertEquals("6#f0.java|10-20|5-10~f5.java|44-54|22-27", signatures.get(0));
-        assertEquals("8#f2.java|46-60|23-30~f5.java|48-62|24-31", signatures.get(signatures.size() - 1));
-
+    private String sha256(List<String> signatures) throws Exception {
         MessageDigest digest = MessageDigest.getInstance("SHA-256");
         digest.update(String.join("\n", signatures).getBytes(StandardCharsets.UTF_8));
         StringBuilder hex = new StringBuilder();
         for (byte b : digest.digest()) {
             hex.append(String.format("%02x", b));
         }
-        assertEquals("5b46454b86b9b26fd0ab68a32d307a0996091e1531c3c041afd9b85f8555642f", hex.toString());
+        return hex.toString();
+    }
+    // A corpus dominated by pairs inside ONE file, which the other corpus does not contain at all.
+    // Blocks are added in ascending cleaned-start order because that is the only order the engine can
+    // produce: FileInfoForDuplication.indexesOf is a forward scan, so occurrences come out ascending.
+    List<DuplicationInstance> sameFileCorpus() {
+        List<DuplicationInstance> duplicates = new ArrayList<>();
+        int state = 987654321;
+        for (int i = 0; i < 300; i++) {
+            state = (state * 1103515245 + 12345) & 0x7fffffff;
+            String file = "s" + (state % 5) + ".java";
+            int first = 1 + (state / 5) % 30;
+            int second = first + 1 + (state / 150) % 25;
+            List<DuplicatedFileBlock> blocks = new ArrayList<>();
+            blocks.add(block(file, first, BLOCK));
+            blocks.add(block(file, second, BLOCK));
+            if (state % 4 == 0) {
+                blocks.add(block(file, second + 1 + (state / 3750) % 10, BLOCK));
+            }
+            if (state % 5 == 0) {
+                blocks.add(block("other" + (state % 3) + ".java", first, BLOCK));
+            }
+            sortAsTheEngineWould(blocks);
+            duplicates.add(instance(BLOCK, blocks.toArray(new DuplicatedFileBlock[0])));
+        }
+        return duplicates;
+    }
+
+
+    // The engine never emits two blocks of one file out of ascending start-line order: indexesOf is a
+    // forward scan, so occurrences arrive ascending. Fixtures respect that, or they describe inputs that
+    // cannot occur.
+    private void sortAsTheEngineWould(List<DuplicatedFileBlock> blocks) {
+        blocks.sort((a, b) -> a.getSourceFile().getRelativePath().equals(b.getSourceFile().getRelativePath())
+                ? Integer.compare(a.getCleanedStartLine(), b.getCleanedStartLine())
+                : a.getSourceFile().getRelativePath().compareTo(b.getSourceFile().getRelativePath()));
     }
 }

--- a/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/analysis/files/DuplicationPerFilePairConsolidationTest.java
+++ b/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/analysis/files/DuplicationPerFilePairConsolidationTest.java
@@ -1,0 +1,236 @@
+package nl.obren.sokrates.sourcecode.analysis.files;
+
+import nl.obren.sokrates.sourcecode.SourceFile;
+import nl.obren.sokrates.sourcecode.analysis.results.CodeAnalysisResults;
+import nl.obren.sokrates.sourcecode.core.CodeConfiguration;
+import nl.obren.sokrates.sourcecode.duplication.DuplicatedFileBlock;
+import nl.obren.sokrates.sourcecode.duplication.DuplicationInstance;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Pins mergeAndConsolidatePerFilePair, which replaces merge() + consolidate(): duplicated block pairs are
+ * grouped by file pair and runs of adjacent pairs are collapsed into a single instance spanning the run.
+ */
+class DuplicationPerFilePairConsolidationTest {
+
+    private static final int BLOCK = 6;
+
+    private DuplicationAnalyzer analyzer() {
+        CodeAnalysisResults analysisResults = new CodeAnalysisResults();
+        analysisResults.setCodeConfiguration(new CodeConfiguration());
+        return new DuplicationAnalyzer(analysisResults);
+    }
+
+    // Raw lines are twice the cleaned lines, so an assertion on startLine/endLine below distinguishes the
+    // raw span from the cleaned one instead of passing for either.
+    private DuplicatedFileBlock block(String path, int cleanedStartLine, int blockSize) {
+        SourceFile sourceFile = new SourceFile(new File(path));
+        sourceFile.setRelativePath(path);
+        DuplicatedFileBlock block = new DuplicatedFileBlock();
+        block.setSourceFile(sourceFile);
+        block.setCleanedStartLine(cleanedStartLine);
+        block.setCleanedEndLine(cleanedStartLine + blockSize - 1);
+        block.setStartLine(cleanedStartLine * 2);
+        block.setEndLine((cleanedStartLine + blockSize - 1) * 2);
+        block.setSourceFileCleanedLinesOfCode(1000);
+        return block;
+    }
+
+    private DuplicationInstance instance(int blockSize, DuplicatedFileBlock... blocks) {
+        DuplicationInstance instance = new DuplicationInstance();
+        instance.setBlockSize(blockSize);
+        instance.getDuplicatedFileBlocks().addAll(Arrays.asList(blocks));
+        return instance;
+    }
+
+    private DuplicationInstance pair(String path1, int start1, String path2, int start2) {
+        return instance(BLOCK, block(path1, start1, BLOCK), block(path2, start2, BLOCK));
+    }
+
+    private List<String> signatures(List<DuplicationInstance> instances) {
+        List<String> signatures = new ArrayList<>();
+        instances.forEach(instance -> {
+            List<String> blocks = new ArrayList<>();
+            instance.getDuplicatedFileBlocks().forEach(block -> blocks.add(
+                    block.getSourceFile().getRelativePath() + "|" + block.getStartLine() + "-" + block.getEndLine()
+                            + "|" + block.getCleanedStartLine() + "-" + block.getCleanedEndLine()));
+            Collections.sort(blocks);
+            signatures.add(instance.getBlockSize() + "#" + String.join("~", blocks));
+        });
+        Collections.sort(signatures);
+        return signatures;
+    }
+
+    @Test
+    void oneSharedBlockBecomesOnePairSpanningExactlyThatBlock() {
+        List<DuplicationInstance> result = analyzer().mergeAndConsolidatePerFilePair(
+                Collections.singletonList(pair("a.java", 10, "b.java", 20)));
+
+        assertEquals(1, result.size());
+        DuplicationInstance consolidated = result.get(0);
+        assertEquals(BLOCK, consolidated.getBlockSize());
+        assertEquals(2, consolidated.getDuplicatedFileBlocks().size());
+
+        DuplicatedFileBlock first = consolidated.getDuplicatedFileBlocks().get(0);
+        DuplicatedFileBlock second = consolidated.getDuplicatedFileBlocks().get(1);
+        // The lower relative path comes first, matching getPairKey's ordering.
+        assertEquals("a.java", first.getSourceFile().getRelativePath());
+        assertEquals("b.java", second.getSourceFile().getRelativePath());
+        assertEquals(10, first.getCleanedStartLine());
+        assertEquals(15, first.getCleanedEndLine());
+        assertEquals(20, first.getStartLine());
+        assertEquals(30, first.getEndLine());
+        assertEquals(20, second.getCleanedStartLine());
+        assertEquals(25, second.getCleanedEndLine());
+    }
+
+    @Test
+    void adjacentPairsCollapseIntoOneInstanceSpanningTheWholeRun() {
+        List<DuplicationInstance> result = analyzer().mergeAndConsolidatePerFilePair(Arrays.asList(
+                pair("a.java", 10, "b.java", 20),
+                pair("a.java", 11, "b.java", 21),
+                pair("a.java", 12, "b.java", 22)));
+
+        assertEquals(1, result.size());
+        DuplicationInstance consolidated = result.get(0);
+        // Three windows of 6 starting one line apart span 8 cleaned lines, not 6 and not 18.
+        assertEquals(8, consolidated.getBlockSize());
+
+        DuplicatedFileBlock first = consolidated.getDuplicatedFileBlocks().get(0);
+        assertEquals(10, first.getCleanedStartLine());
+        assertEquals(17, first.getCleanedEndLine());
+        assertEquals(20, first.getStartLine());
+        assertEquals(34, first.getEndLine());
+
+        DuplicatedFileBlock second = consolidated.getDuplicatedFileBlocks().get(1);
+        assertEquals(20, second.getCleanedStartLine());
+        assertEquals(27, second.getCleanedEndLine());
+        assertEquals(40, second.getStartLine());
+        assertEquals(54, second.getEndLine());
+    }
+
+    @Test
+    void aRunIsOnlyAdjacentWhenBothSidesAdvanceTogether() {
+        // b advances by two while a advances by one, so these are two separate duplicates rather than a run.
+        List<DuplicationInstance> result = analyzer().mergeAndConsolidatePerFilePair(Arrays.asList(
+                pair("a.java", 10, "b.java", 20),
+                pair("a.java", 11, "b.java", 22)));
+
+        assertEquals(2, result.size());
+        result.forEach(instance -> assertEquals(BLOCK, instance.getBlockSize()));
+    }
+
+    @Test
+    void separateRunsInTheSameFilePairStayApart() {
+        List<DuplicationInstance> result = analyzer().mergeAndConsolidatePerFilePair(Arrays.asList(
+                pair("a.java", 10, "b.java", 20),
+                pair("a.java", 11, "b.java", 21),
+                pair("a.java", 30, "b.java", 40)));
+
+        assertEquals(2, result.size());
+        List<Integer> blockSizes = new ArrayList<>();
+        result.forEach(instance -> blockSizes.add(instance.getBlockSize()));
+        Collections.sort(blockSizes);
+        assertEquals(Arrays.asList(BLOCK, 7), blockSizes);
+    }
+
+    @Test
+    void aRunStartingOnTheFirstLineIsNotTreatedAsAContinuation() {
+        // The chain-head test probes (start - 1); at line 1 that probe addresses line 0, which must simply
+        // be absent rather than wrapping or matching.
+        List<DuplicationInstance> result = analyzer().mergeAndConsolidatePerFilePair(Arrays.asList(
+                pair("a.java", 1, "b.java", 1),
+                pair("a.java", 2, "b.java", 2)));
+
+        assertEquals(1, result.size());
+        assertEquals(7, result.get(0).getBlockSize());
+        assertEquals(1, result.get(0).getDuplicatedFileBlocks().get(0).getCleanedStartLine());
+    }
+
+    @Test
+    void aBlockSharedByThreeFilesBecomesOneInstancePerFilePair() {
+        List<DuplicationInstance> result = analyzer().mergeAndConsolidatePerFilePair(
+                Collections.singletonList(instance(BLOCK,
+                        block("a.java", 10, BLOCK), block("b.java", 20, BLOCK), block("c.java", 30, BLOCK))));
+
+        assertEquals(3, result.size());
+        assertEquals(Arrays.asList(
+                "6#a.java|20-30|10-15~b.java|40-50|20-25",
+                "6#a.java|20-30|10-15~c.java|60-70|30-35",
+                "6#b.java|40-50|20-25~c.java|60-70|30-35"), signatures(result));
+    }
+
+    @Test
+    void twoBlocksInTheSameFileAreKeptAsADuplicateOfThatFileWithItself() {
+        List<DuplicationInstance> result = analyzer().mergeAndConsolidatePerFilePair(
+                Collections.singletonList(instance(BLOCK, block("a.java", 30, BLOCK), block("a.java", 10, BLOCK))));
+
+        assertEquals(1, result.size());
+        DuplicationInstance consolidated = result.get(0);
+        assertEquals("a.java", consolidated.getDuplicatedFileBlocks().get(0).getSourceFile().getRelativePath());
+        assertEquals("a.java", consolidated.getDuplicatedFileBlocks().get(1).getSourceFile().getRelativePath());
+        // Within one file the lower cleaned start line comes first, whatever order the blocks arrived in.
+        assertEquals(10, consolidated.getDuplicatedFileBlocks().get(0).getCleanedStartLine());
+        assertEquals(30, consolidated.getDuplicatedFileBlocks().get(1).getCleanedStartLine());
+    }
+
+    @Test
+    void anInstanceWithASingleBlockContributesNoPair() {
+        List<DuplicationInstance> result = analyzer().mergeAndConsolidatePerFilePair(
+                Collections.singletonList(instance(BLOCK, block("a.java", 10, BLOCK))));
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void noDuplicatesProduceNoInstances() {
+        assertTrue(analyzer().mergeAndConsolidatePerFilePair(new ArrayList<>()).isEmpty());
+    }
+
+    @Test
+    void theSamePairReportedByTwoInstancesIsEmittedOnce() {
+        List<DuplicationInstance> result = analyzer().mergeAndConsolidatePerFilePair(Arrays.asList(
+                pair("a.java", 10, "b.java", 20),
+                pair("a.java", 10, "b.java", 20)));
+
+        assertEquals(1, result.size());
+        assertEquals(BLOCK, result.get(0).getBlockSize());
+    }
+
+    @Test
+    void producesTheSameSetAsTheMapBasedImplementation() {
+        // Deterministic pseudo-random corpus: overlapping runs, shared blocks, intra-file pairs and repeats,
+        // so agreement here is agreement over the shapes the engine actually emits.
+        List<DuplicationInstance> duplicates = new ArrayList<>();
+        int state = 12345;
+        for (int i = 0; i < 400; i++) {
+            state = (state * 1103515245 + 12345) & 0x7fffffff;
+            int fileA = state % 7;
+            int fileB = (state / 7) % 7;
+            int startA = 1 + (state / 49) % 40;
+            int startB = 1 + (state / 2401) % 40;
+            List<DuplicatedFileBlock> blocks = new ArrayList<>();
+            blocks.add(block("f" + fileA + ".java", startA, BLOCK));
+            blocks.add(block("f" + fileB + ".java", startB, BLOCK));
+            if (state % 3 == 0) {
+                blocks.add(block("f" + ((fileA + 3) % 7) + ".java", startA + 1, BLOCK));
+            }
+            duplicates.add(instance(BLOCK, blocks.toArray(new DuplicatedFileBlock[0])));
+        }
+
+        DuplicationAnalyzer analyzer = analyzer();
+        List<String> legacy = signatures(new ArrayList<>(analyzer.consolidate(analyzer.merge(duplicates)).values()));
+        List<String> bucketed = signatures(analyzer.mergeAndConsolidatePerFilePair(duplicates));
+
+        assertFalse(legacy.isEmpty());
+        assertEquals(legacy, bucketed);
+    }
+}

--- a/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/analysis/files/DuplicationPerFilePairConsolidationTest.java
+++ b/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/analysis/files/DuplicationPerFilePairConsolidationTest.java
@@ -8,6 +8,8 @@ import nl.obren.sokrates.sourcecode.duplication.DuplicationInstance;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -20,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * grouped by file pair and runs of adjacent pairs are collapsed into a single instance spanning the run.
  */
 class DuplicationPerFilePairConsolidationTest {
+
 
     private static final int BLOCK = 6;
 
@@ -205,10 +208,9 @@ class DuplicationPerFilePairConsolidationTest {
         assertEquals(BLOCK, result.get(0).getBlockSize());
     }
 
-    @Test
-    void producesTheSameSetAsTheMapBasedImplementation() {
-        // Deterministic pseudo-random corpus: overlapping runs, shared blocks, intra-file pairs and repeats,
-        // so agreement here is agreement over the shapes the engine actually emits.
+    // Deterministic pseudo-random corpus: overlapping runs, shared blocks, intra-file pairs and repeats,
+    // so agreement over it is agreement over the shapes the engine actually emits.
+    List<DuplicationInstance> pseudoRandomCorpus() {
         List<DuplicationInstance> duplicates = new ArrayList<>();
         int state = 12345;
         for (int i = 0; i < 400; i++) {
@@ -225,12 +227,26 @@ class DuplicationPerFilePairConsolidationTest {
             }
             duplicates.add(instance(BLOCK, blocks.toArray(new DuplicatedFileBlock[0])));
         }
+        return duplicates;
+    }
 
-        DuplicationAnalyzer analyzer = analyzer();
-        List<String> legacy = signatures(new ArrayList<>(analyzer.consolidate(analyzer.merge(duplicates)).values()));
-        List<String> bucketed = signatures(analyzer.mergeAndConsolidatePerFilePair(duplicates));
+    @Test
+    void reproducesTheOutputOfTheMapBasedImplementation() throws Exception {
+        // Golden values recorded from the previous merge()+consolidate() implementation over this corpus,
+        // before it was removed. They are what makes this a behaviour-preserving change rather than a
+        // plausible rewrite, so they must not be re-recorded from the current code to make a failure pass.
+        List<String> signatures = signatures(analyzer().mergeAndConsolidatePerFilePair(pseudoRandomCorpus()));
 
-        assertFalse(legacy.isEmpty());
-        assertEquals(legacy, bucketed);
+        assertEquals(577, signatures.size());
+        assertEquals("6#f0.java|10-20|5-10~f5.java|44-54|22-27", signatures.get(0));
+        assertEquals("8#f2.java|46-60|23-30~f5.java|48-62|24-31", signatures.get(signatures.size() - 1));
+
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        digest.update(String.join("\n", signatures).getBytes(StandardCharsets.UTF_8));
+        StringBuilder hex = new StringBuilder();
+        for (byte b : digest.digest()) {
+            hex.append(String.format("%02x", b));
+        }
+        assertEquals("5b46454b86b9b26fd0ab68a32d307a0996091e1531c3c041afd9b85f8555642f", hex.toString());
     }
 }


### PR DESCRIPTION
**What breaks today** — a highly duplicated repository of only 12.6 MB needs close to 3 GB to analyse, and dies with `OutOfMemoryError` below that.

**What this changes** — duplicated block pairs are grouped by file pair, instead of every pair being materialised into one global map.

**What it buys** — smallest heap that completes **~2.9 GB → ~1.1 GB**; consolidation **10.2 s → 2.4 s**; ordinary repositories unchanged within noise; analysis results identical, verified instance by instance across four repositories.

---

## The problem

Analysing a repository whose code is highly duplicated can exhaust the heap during duplication analysis, and the amount of code needed to do it is small. A synthetic repository of **1,351 files and 12.6 MB** of Java — every file assembled from a pool of 200 shared blocks — needs **close to 3 GB** to analyse. Ordinary repositories many times that size analyse comfortably in a fraction of it.

The cost is not in the duplication engine. The engine finds 14,800 duplication instances on that repository and holds them in **18 MB**. It is `DuplicationAnalyzer` that then turns them into **8,261,323 map entries occupying 2,735 MB**, before collapsing them straight back down to 195,937 instances in 211 MB. The entire footprint exists for the duration of two method calls.

## Why

`merge()` created a `DuplicationInstance`, two copied `DuplicatedFileBlock`s, an ~89-byte composite `"pathA:lineA::pathB:lineB"` key and a map node for **every ordered pair of blocks inside every instance** — about 300 bytes per pair, and the number of pairs grows with the square of how many places a block appears in. `consolidate()` then walked chains of adjacent pairs and merged them back into single instances, discarding almost all of what `merge()` had just built.

Measured at `-Xmx2g`, the failure lands exactly there, with the engine already finished:

```
java.lang.OutOfMemoryError: Java heap space
    at nl.obren.sokrates.sourcecode.duplication.DuplicationInstance.<init>(DuplicationInstance.java:18)
    at nl.obren.sokrates.sourcecode.analysis.files.DuplicationAnalyzer.lambda$merge$3(DuplicationAnalyzer.java:205)
```

## The change

Every chain `consolidate()` walked is local to **one unordered file pair**: `getPairKey` held the two paths fixed and only advanced the start lines. So the global map is not needed. The pairs are grouped by file pair, each held as a packed `long` — the two cleaned start lines — instead of an object graph, and the chains are walked inside each bucket. On the repository above that is 58,737 buckets of at most 296 entries.

`merge()`, `consolidate()` and `getPairKey()` are replaced by one method, `mergeAndConsolidatePerFilePair`.

## Measured

The smallest heap that completes on the clone-dense repository, three runs per point, all unanimous:

| | 1g | 1152m | 1536m | 2g | 2816m | 3g |
| --- | --- | --- | --- | --- | --- | --- |
| before | fail | fail | fail | fail | fail | **pass** |
| after | fail | **pass** | pass | pass | pass | pass |

**~2.9 GB → ~1.1 GB.** Peak RSS under a large `-Xmx` barely moves, because it tracks how far the heap grew rather than what was live; the smallest heap that completes is the figure that decides whether an analysis survives.

It is also faster, because ~8.26 M object graphs and ~8.7 M string keys are never built:

| repository | duplication phase | consolidation step |
| --- | --- | --- |
| clone-dense (1,351 files) | 18,884 → **9,999 ms** | 10,156 → **2,356 ms** |
| sokrates (947 files) | 582 → 561 ms | 13 → 10 ms |
| spring-framework (9,248 Java files) | 2,063 → 2,024 ms | 31 → 27 ms |
| a 1,312-file TypeScript repository | 727 → 718 ms | 8 → 9 ms |

Ordinary repositories are unchanged within noise; nothing measured got slower or larger.

## Results are the same

Both implementations were run in one JVM over all four repositories and their full consolidated sets compared — every instance's `blockSize` and every block's path, `startLine`, `endLine`, `cleanedStartLine`, `cleanedEndLine` and `sourceFileCleanedLinesOfCode`:

| repository | instances | identical | unique to either side |
| --- | --- | --- | --- |
| clone-dense | 195,937 | yes | 0 |
| sokrates | 1,247 | yes | 0 |
| spring-framework | 2,534 | yes | 0 |
| TypeScript repository | 1,891 | yes | 0 |

Against report output generated by the previous code, `overallDuplication`, `duplicationPerExtension`, `duplicationPerComponent` and `duplicationPerConcern` are byte-identical on all four, and `text/duplicates.txt` is set-identical on the three real ones.

**Two differences worth stating plainly.**

1. **List order changes, so a capped list can show different members.** `longestDuplicates` keeps an identical `blockSize` sequence on all four repositories — duplicates of different length are ordered exactly as before — but where several duplicates tie on length, a different subset of them fills the top 50. The same applies to `DataExporter`'s 10,000-row export cap on a repository with more duplicates than that.

2. **`mostFrequentDuplicates` differs in the order of blocks within an instance**, never in which instances or in what order. Two runs of the *unmodified* previous build differ the same way: it reads the engine's list directly, which this change does not touch, and the engine fills that list from a `ConcurrentHashMap` under a parallel traversal.

## Tests

14 cases in `DuplicationPerFilePairConsolidationTest`, including two golden tests whose expected values were recorded from `merge()`+`consolidate()` before it was removed, over two corpora — one general (577 instances) and one dominated by pairs inside a single file (466 instances, 381 of them same-file). Mutation-checked, one mutation per element; all eleven mutations were killed.

Both corpora sort each instance's blocks the way the engine does, because `FileInfoForDuplication.indexesOf` is a forward scan and returns a block's occurrences in ascending order. That matters: fed blocks in descending order — which the engine cannot produce — the two implementations order a same-file pair differently, since `merge()` ordered such a pair by arrival and `inPairKeyOrder` orders it by start line.

## One question for you

`getPairKey` was `public`, but it existed to build the keys of `merge()`'s map and had no other caller anywhere in the five modules, so it is deleted here along with its test, and the ordering it encoded now has a single definition in `inPairKeyOrder`. Deleting a public method and a passing test is your call — say the word and I will restore both.
