### PR TITLE
Ignore the git-commit-trailers.txt sidecar when scoping files

### DIFF
--- a/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/scoping/ScopingConventions.java
+++ b/codeanalyzer/src/main/java/nl/obren/sokrates/sourcecode/scoping/ScopingConventions.java
@@ -538,7 +538,7 @@ public class ScopingConventions {
 
         ignoredFilesConventions.add(new Convention(".*/node_modules/.*", "", "Node dependencies"));
         ignoredFilesConventions.add(new Convention(".*/git[-]history[.]txt", "", "Git history"));
-        ignoredFilesConventions.add(new Convention(".*/git]-]commit[-]trailers[.]txt", "", "Git history trailers"));
+        ignoredFilesConventions.add(new Convention(".*/git[-]commit[-]trailers[.]txt", "", "Git history trailers"));
         ignoredFilesConventions.add(new Convention(".*/git[-]merges[.]txt", "", "Git merges"));
         ignoredFilesConventions.add(new Convention(".*/bower_components/.*", "", "Bower components"));
 

--- a/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/scoping/ScopingConventionsGitSidecarsTest.java
+++ b/codeanalyzer/src/test/java/nl/obren/sokrates/sourcecode/scoping/ScopingConventionsGitSidecarsTest.java
@@ -1,0 +1,91 @@
+package nl.obren.sokrates.sourcecode.scoping;
+
+import nl.obren.sokrates.sourcecode.githistory.GitHistoryUtils;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression tests for the ignore conventions that keep the git-history export out of the scoped
+ * source files.
+ *
+ * <p>{@code extractGitHistory} writes {@code git-history.txt} plus two optional sidecars next to it,
+ * {@code git-commits.txt} and {@code git-commit-trailers.txt} (see {@link GitHistoryUtils}), and
+ * {@code extractGitSubHistory} copies the sidecars into each split folder. All of them are analysis
+ * inputs, not source code, so a repository whose configuration lists {@code txt} among its extensions
+ * must not count them in any scope. The trailers file was not ignored: its rule was spelled
+ * {@code git]-]commit[-]trailers} (two literal {@code ]} where a character class was meant), so it
+ * matched nothing. {@code git-commits.txt} has no rule of its own but is covered by the generic
+ * {@code git[-][a-zA-Z0-9_]+[.]txt} export rule, which the second hyphen in
+ * {@code git-commit-trailers.txt} keeps out of.
+ */
+class ScopingConventionsGitSidecarsTest {
+
+    private final ScopingConventions conventions = new ScopingConventions();
+
+    private boolean matchesAny(List<Convention> rules, String path) {
+        return rules.stream().anyMatch(c -> c.pathMatches(path));
+    }
+
+    private void assertIgnored(String path) {
+        assertTrue(matchesAny(conventions.getIgnoredFilesConventions(), path),
+                "expected to be ignored but was not: " + path);
+    }
+
+    private void assertNotIgnored(String path) {
+        assertFalse(matchesAny(conventions.getIgnoredFilesConventions(), path),
+                "expected NOT to be ignored but was: " + path);
+    }
+
+    // --- every file the history extraction writes is ignored --------------------------------------
+
+    @Test
+    void historyFileIsIgnored() {
+        assertIgnored("/repo/" + GitHistoryUtils.GIT_HISTORY_FILE_NAME);
+        assertIgnored("../" + GitHistoryUtils.GIT_HISTORY_FILE_NAME);
+    }
+
+    @Test
+    void commitsSidecarIsIgnored() {
+        assertIgnored("/repo/" + GitHistoryUtils.GIT_COMMITS_FILE_NAME);
+        assertIgnored("../" + GitHistoryUtils.GIT_COMMITS_FILE_NAME);
+    }
+
+    @Test
+    void commitTrailersSidecarIsIgnored() {
+        assertIgnored("/repo/" + GitHistoryUtils.GIT_COMMIT_TRAILERS_FILE_NAME);
+        assertIgnored("../" + GitHistoryUtils.GIT_COMMIT_TRAILERS_FILE_NAME);
+    }
+
+    @Test
+    void mergesFileIsIgnored() {
+        assertIgnored("/repo/git-merges.txt");
+    }
+
+    @Test
+    void sidecarsCopiedIntoSubHistoryFoldersAreIgnored() {
+        // extractGitSubHistory copies the sidecars verbatim into each split folder.
+        assertIgnored("/repo/module-a/" + GitHistoryUtils.GIT_COMMITS_FILE_NAME);
+        assertIgnored("/repo/module-a/" + GitHistoryUtils.GIT_COMMIT_TRAILERS_FILE_NAME);
+    }
+
+    @Test
+    void windowsStyleSidecarPathsAreIgnored() {
+        assertIgnored("C:\\repo\\" + GitHistoryUtils.GIT_COMMITS_FILE_NAME);
+        assertIgnored("C:\\repo\\" + GitHistoryUtils.GIT_COMMIT_TRAILERS_FILE_NAME);
+    }
+
+    // --- the rules name one file each, not a family -----------------------------------------------
+
+    @Test
+    void similarlyNamedSourceFilesAreNotIgnored() {
+        assertNotIgnored("/repo/notes/git-commits.md");
+        assertNotIgnored("/repo/git-commits.txt.bak");
+        assertNotIgnored("/repo/mygit-commits.txt");
+        assertNotIgnored("/repo/git-commit-trailers.java");
+        assertNotIgnored("/repo/git-commit-trailers-parser.txt");
+    }
+}


### PR DESCRIPTION
## What

`extractGitHistory` writes `git-commit-trailers.txt` next to `git-history.txt`, and `extractGitSubHistory` copies it into each split folder. The ignore convention meant to keep it out of the scoped files was spelled `.*/git]-]commit[-]trailers[.]txt`: the first `]-]` is two literal `]` around a literal `-`, not a character class, so the rule matched nothing. In a repository whose configuration lists `txt` among its extensions the sidecar was scoped like any other root-level text file and counted there.

The fix is the intended character class, `.*/git[-]commit[-]trailers[.]txt`. One line in `ScopingConventions`.

The other three git export files were already ignored: `git-history.txt` and `git-merges.txt` by their own rules, `git-commits.txt` by the generic `.*/git[-][a-zA-Z0-9_]+[.]txt` export rule, which the second hyphen in `git-commit-trailers.txt` keeps it out of. No new rule is added for them.

## Test

`ScopingConventionsGitSidecarsTest` (same style as `ScopingConventionsMockFoldersTest`) pins all four files as ignored at the root, under a relative root, in a sub-history folder and in Windows form, and pins that look-alike names (`git-commits.md`, `git-commits.txt.bak`, `mygit-commits.txt`, `git-commit-trailers.java`) are not ignored. It fails on the previous spelling (three assertions, all naming `git-commit-trailers.txt`) and passes with this one.

## Verification

- `mvn clean install` green on all modules.
- CLI run over a scratch folder holding `notes.txt` and all four git files, with `txt` as the only extension: `init` writes the corrected rule into `config.json`; `generateReports` (default config path and absolute path) reports 4 excluded files and leaves only `notes.txt` in the `other` scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vt3y1r4ee65Zb9L91urxVQ
